### PR TITLE
added custom PDB URI option for the download function

### DIFF
--- a/3Dmol/3dmol.js
+++ b/3Dmol/3dmol.js
@@ -89,17 +89,19 @@ $3Dmol.viewers = {};
 $3Dmol.download = function(query, viewer, options, callback) {
     var baseURL = '';
     var type = "";
+    var pdbUri = "";
     var m = viewer.addModel();
     if (query.substr(0, 4) === 'pdb:') {
+        pdbUri = options && options.pdbUri ? options.pdbUri : "http://www.rcsb.org/pdb/files/";
         type = options && options.format ? options.format : "pdb";
         query = query.substr(4).toUpperCase();
         if (!query.match(/^[1-9][A-Za-z0-9]{3}$/)) {
            alert("Wrong PDB ID"); return;
         }
         if (options && options.format)
-            uri = "http://www.rcsb.org/pdb/files/" + query + "." + options.format;
+            uri = pdbUri + query + "." + options.format;
         else
-            uri = "http://www.rcsb.org/pdb/files/" + query + ".pdb"; 
+            uri = pdbUri + query + ".pdb";
 
     } else if (query.substr(0, 4) == 'cid:') {
         type = "sdf";


### PR DESCRIPTION
This allows users to customize previously hard-coded PDB download URL. This is especially useful when requesting PDB data through a proxy within a secure (HTTPS) web application.