### PR TITLE
Added vasp POSCAR/CONTCAR files model parser

### DIFF
--- a/3Dmol/parsers.js
+++ b/3Dmol/parsers.js
@@ -346,6 +346,94 @@ $3Dmol.Parsers = (function() {
      * @param {Object}
      *            options
      */
+    parsers.vasp = parsers.VASP = function (str, options) {
+      var atoms = [[]];
+      var lattice = {};
+
+      var lines = str.replace(/^\s+/, "").split(/[\n\r]/);
+
+      if (lines.length < 3){
+        return atoms;
+      }
+
+      if (lines[1].match(/\d+/)) {
+        lattice.length = parseFloat(lines[1]);
+      } else {
+        console.log("Warning: second line of the vasp structure file must be a number");
+        return atoms;
+      }
+
+      if (lattice.length<0) {
+        console.log("Warning: Vasp implementation for negative lattice lengths is not yet available");
+        return atoms;
+      }
+
+      lattice.xVec = new Float32Array(lines[2].replace(/^\s+/, "").split(/\s+/));
+      lattice.yVec = new Float32Array(lines[3].replace(/^\s+/, "").split(/\s+/));
+      lattice.zVec = new Float32Array(lines[4].replace(/^\s+/, "").split(/\s+/));
+
+
+      var atomSymbols=lines[5].replace(/\s+/, "").split(/\s+/);
+      var atomSpeciesNumber=new Int16Array(lines[6].replace(/^\s+/, "").split(/\s+/));
+      var vaspMode=lines[7].replace(/\s+/, "");
+
+
+      if (vaspMode.match(/C/)) {
+        vaspMode = "cartesian";
+      }else if (vaspMode.match(/D/)){
+        vaspMode="direct";
+      } else {
+        console.log("Warning: Unknown vasp mode in POSCAR file: mode must be either C(artesian) or D(irect)");
+        return atoms;
+      }
+
+      if (atomSymbols.length != atomSpeciesNumber.length) {
+        console.log("Warning: declaration of atomary species wrong:");
+        console.log(atomSymbols);
+        console.log(atomSpeciesNumber);
+        return atoms;
+      }
+
+      lines.splice(0,8);
+
+      var atomCounter = 0;
+
+      for (var i = 0, len = atomSymbols.length; i < len; i++) {
+        var atomSymbol = atomSymbols[i];
+       for (var j = 0, atomLen = atomSpeciesNumber[i]; j < atomLen; j++) {
+
+        var coords = new Float32Array(lines[atomCounter + j].replace(/^\s+/, "").split(/\s+/));
+
+        atom={};
+        atom.elem = atomSymbol;
+        if (vaspMode == "cartesian") {
+          atom.x = lattice.length*coords[0];
+          atom.y = lattice.length*coords[1];
+          atom.z = lattice.length*coords[2];
+        } else {
+          atom.x = lattice.length*(coords[0]*lattice.xVec[0] + coords[1]*lattice.yVec[0] + coords[2]*lattice.zVec[0]);
+          atom.y = lattice.length*(coords[0]*lattice.xVec[1] + coords[1]*lattice.yVec[1] + coords[2]*lattice.zVec[1]);
+          atom.z = lattice.length*(coords[0]*lattice.xVec[2] + coords[1]*lattice.yVec[2] + coords[2]*lattice.zVec[2]);
+        }
+
+        atom.bonds=[];
+
+        atoms[0].push(atom);
+       }
+        atomCounter += atomSpeciesNumber[i];
+      }
+
+      return atoms;
+
+
+    }
+
+    /**
+     * @param {string}
+     *            str
+     * @param {Object}
+     *            options
+     */
     parsers.cube = parsers.CUBE = function(str, options) {
         var atoms = [[]];
         var lines = str.replace(/^\s+/, "").split(/\n\r|\r+/);


### PR DESCRIPTION
This parser needs that the atomic symbols are explicitly provided in 
the POSCAR file, this is in VASP optional but for parsing purposes 
necessary. If this were not the case a warning is echoed. 