### PR TITLE
Explicit Typed Array Length

### DIFF
--- a/3Dmol/WebGL/core.js
+++ b/3Dmol/WebGL/core.js
@@ -434,13 +434,13 @@ $3Dmol.Geometry = (function() {
             if(this.lineidx > 0) //not always set so reclaim memory
                 this.lineArray = lineArr.subarray(0,this.lineidx); 
             else
-                this.lineArray = new Uint16Array();
+                this.lineArray = new Uint16Array(0);
                         
         }        
         else {
-            this.normalArray = new Float32Array(); 
-            this.faceArray = new Uint16Array(); 
-            this.lineArray = new Uint16Array(); 
+            this.normalArray = new Float32Array(0);
+            this.faceArray = new Uint16Array(0);
+            this.lineArray = new Uint16Array(0);
         }
         if (radiusArr) {
             this.radiusArray = radiusArr.subarray(0, this.vertices);

--- a/js/mmtf.js
+++ b/js/mmtf.js
@@ -607,7 +607,7 @@
   }
 
   function encodeRun( array ){
-      if( array.length === 0 ) return new Int32Array();
+      if( array.length === 0 ) return new Int32Array(0);
       var i, il;
       // calculate output size
       var fullLength = 2;


### PR DESCRIPTION
Typed array constructors should throw an error when called with no arguments according to the [ecmascript spec](http://www.ecma-international.org/ecma-262/6.0/#table-49).  There are a few places in this project that don't pass arguments, so this PR fixes them by just passing `0`.

The latest version of Chrome doesn't throw an error like it should, so most people probably don't notice that this is wrong.  However, [core-js](https://github.com/zloirock/core-js), which is used in Babel's popular [polyfill](https://babeljs.io/docs/usage/polyfill/), does throw an error and causes 3Dmol to break entirely.

Let me know if there are any other places in the codebase I missed!