### PR TITLE
Fix missing variable declaration

### DIFF
--- a/3Dmol/glmodel.js
+++ b/3Dmol/glmodel.js
@@ -791,7 +791,9 @@ $3Dmol.GLModel = (function() {
                     } 
                     
                     else if (atom.bondOrder[i] > 1) {
-                        var mfromCap = 0; mtoCap = 0; //multi bond caps
+                        //multi bond caps
+                        var mfromCap = 0;
+                        var mtoCap = 0;
                         
                         if(bondR != atomBondR) {
                             //assume jmol style multiple bonds - the radius doesn't fit within atom sphere


### PR DESCRIPTION
A variable was used without a declaration, which is either going to automatically declare it on `window` or throw an error, both of which are bad!  This fixes it by declaring the variable.