### PR TITLE
NPM Module Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,10 @@
     "grunt-contrib-uglify": "^0.5.0",
     "grunt-node-inspector": "^0.1.5",
     "grunt-shell": "^0.7.0"
-  }
+  },
+  "scripts": {
+    "build": "grunt build",
+    "prepublish": "npm run build"
+  },
+  "main": "build/3Dmol-min.js"
 }


### PR DESCRIPTION
This project was published as an npm module in issue https://github.com/3dmol/3Dmol.js/issues/202, but it was still lacking the ability to easily be used in this way.  This PR includes the build directory and points to one of the output files as a main so that the project can be required (or used via script tag pointing to the build directory via node_modules).

.npmignore was added to tell npm to include things ignored by .gitignore when publishing, like the build directory.  The npm docs explain this: https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package.

Further work could improve this a bit, like using jQuery as a dependency via npm for deduplication in projects, but this should get us started with making this project useful as an npm module.