### PR TITLE
Change name casing to match the published NPM name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "3Dmol",
+  "name": "3dmol",
   "version": "1.0.6",
   "description": "Object oriented Javascript molecular visualization library",
   "repository": {


### PR DESCRIPTION
I haven't experienced any issues with this but a webpack build I'm working with throws up an error saying it would cause issues on case sensitive file systems. Resolves #266 