### PR TITLE
Fix worker creation for minified systems

### DIFF
--- a/3Dmol/SurfaceWorker.js
+++ b/3Dmol/SurfaceWorker.js
@@ -27,7 +27,9 @@ $3Dmol.workerString = function(){
     
 }.toString().replace(/(^.*?\{|\}$)/g, "");
 
-$3Dmol.workerString += "; var ProteinSurface=" + $3Dmol.ProteinSurface.toString().replace(/\$3Dmol.MarchingCube./g, "MarchingCube.");
+// NOTE: variable replacement is simplified
+// (See: http://stackoverflow.com/questions/1661197/what-characters-are-valid-for-javascript-variable-names)
+$3Dmol.workerString += "; var ProteinSurface=" + $3Dmol.ProteinSurface.toString().replace(/[a-zA-Z_$]{1}[0-9a-zA-Z_$]*.MarchingCube./g, "MarchingCube.");
 $3Dmol.workerString += ",MarchingCube=("+$3Dmol.MarchingCubeInitializer.toString() +")();";
 
 $3Dmol.SurfaceWorker = window.URL ? window.URL.createObjectURL(new Blob([$3Dmol.workerString],{type: 'text/javascript'})) : {postMessage:function(){}};


### PR DESCRIPTION
I've run into a problem with the workerString in a minified production system I have.

The problem is with this part:

`.replace(/\$3Dmol.MarchingCube./g, "MarchingCube.")`

In my production system `$3Dmol` is minified to the variable `l`, so the above replace doesn't do anything and I get an error of `l is undefined`.

I'm using the supplied patch currently which tries to find any `AnyJavaScriptVariable.MarchingCube.` instead of only `$3Dmol.MarchingCube.`. It's far from an ideal solution, but thought I'd flag the issue here now until I have more time to look into web workers and think of a better solution.