### PR TITLE
Patch for png feature in viewer

### DIFF
--- a/viewer.css
+++ b/viewer.css
@@ -89,7 +89,7 @@ this may change*/
     display:none;
 }
 
-#renderModel,#centerModel,#vrmlExport{
+#savePng,#centerModel,#vrmlExport{
     width:30%;
     height:25px;
     margin-top:5px;

--- a/viewer.html
+++ b/viewer.html
@@ -267,7 +267,7 @@ $(document).ready(function(){
 </ul>
 <div id="fixed_bottom">
     <button id="addStyle" onclick="addSelection('style')">Add Style</button><button id="addSurface" onclick="addSelection('surface')">Add Surface</button><button id="addLabelRes" onclick="addSelection('labelres')">Add LabelRes</button>
-    <button id="renderModel" onclick="render(true);">Render</button><button onclick="center();" id="centerModel">Center</button><button onclick="vrml();" id="vrmlExport">VRML</button>
+    <button id="savePng" onclick="savePng();">Save PNG</button><button onclick="center();" id="centerModel">Center</button><button onclick="vrml();" id="vrmlExport">VRML</button>
 </div>
             
 </div>

--- a/viewer.js
+++ b/viewer.js
@@ -811,6 +811,17 @@ var vrml = function() {
     var blob = new Blob([text], {type: "text/plain;charset=utf-8"});
     saveAs(blob, filename);
 }
+var savePng = function() {
+    var filename = "3dmol.png";
+    var text = glviewer.pngURI();
+    var ImgData = text;
+    var link = document.createElement('a');
+    link.href = ImgData;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+}
 //initializes the sidebar based on the given url
 var initSide = function(url){
     var list = document.createElement('ul')
@@ -832,13 +843,13 @@ var toggleHide =  function(){
     if(toggle){        
         $("#menu").css("display","none");
         $("#sidenav").css("width",width+"px");
-        $('#addStyle,#addSurface,#addLabelRes,#centerModel,#renderModel,#vrmlExport').css("display","inline")
+        $('#addStyle,#addSurface,#addLabelRes,#centerModel,#savePng,#vrmlExport').css("display","inline")
         $('#header').css("display","block");
         glviewer.translate(width/2,0,400,false);
         glviewer.render();
     }else{
         $("#sidenav").css("width","0");
-        $('#addStyle,#addSurface,#addLabelRes,#centerModel,#renderModel,#header,#vrmlExport').css("display","none")
+        $('#addStyle,#addSurface,#addLabelRes,#centerModel,#savePng,#header,#vrmlExport').css("display","none")
         $("#menu").css("display","inline");
         width = $("#sidenav").width();
         glviewer.translate(-width/2,0,400,false);


### PR DESCRIPTION
Solves issue #402 
Remove unnecessary *Render* button.
Added *Save as PNG* option. 

Screenshots:
The image saved as png:
![3dmol(2)](https://user-images.githubusercontent.com/32260607/55643982-279fd880-57f2-11e9-870a-bb075cd4e835.png)