### PR TITLE
late fixes for merging the volumetric render module

### DIFF
--- a/3Dmol/WebGL/renderer.js
+++ b/3Dmol/WebGL/renderer.js
@@ -129,7 +129,7 @@ $3Dmol.Renderer = function(parameters) {
     var _gl;
 
     initGL();
-    this.offscreen = initOffScreenRender();
+    this.offscreen = initOffScreenRender(parameters.containerWidth, parameters.containerHeight);
     setDefaultGLState();
 
     this.context = _gl;
@@ -1898,13 +1898,13 @@ $3Dmol.Renderer = function(parameters) {
         }
     }
 
-    function initOffScreenRender(){
+    function initOffScreenRender(width, height){
         // only needed/works with webgl2
         if (_gl.getParameter(_gl.VERSION)[6] == "1") return; 
 
         var targetTexture = _gl.createTexture();
         _gl.bindTexture(_gl.TEXTURE_2D, targetTexture);
-        _gl.texImage2D(_gl.TEXTURE_2D, 0, _gl.RGBA, window.innerWidth, window.innerHeight, 0,
+        _gl.texImage2D(_gl.TEXTURE_2D, 0, _gl.RGBA, width, height, 0,
                 _gl.RGBA, _gl.UNSIGNED_BYTE, null);
 	    _gl.texParameteri(_gl.TEXTURE_2D, _gl.TEXTURE_MIN_FILTER, _gl.LINEAR);
 	    _gl.texParameteri(_gl.TEXTURE_2D, _gl.TEXTURE_MAG_FILTER, _gl.LINEAR);
@@ -1917,7 +1917,7 @@ $3Dmol.Renderer = function(parameters) {
 		// i mean it can't be left out here that easily
 		var depthTexture = _gl.createTexture();
 		_gl.bindTexture(_gl.TEXTURE_2D, depthTexture);
-		_gl.texImage2D(_gl.TEXTURE_2D, 0, _gl.DEPTH_COMPONENT16, window.innerWidth, window.innerHeight, 0,
+		_gl.texImage2D(_gl.TEXTURE_2D, 0, _gl.DEPTH_COMPONENT16, width, height, 0,
 				_gl.DEPTH_COMPONENT, _gl.UNSIGNED_INT, null);
 		_gl.texParameteri(_gl.TEXTURE_2D, _gl.TEXTURE_MIN_FILTER, _gl.NEAREST);
 		_gl.texParameteri(_gl.TEXTURE_2D, _gl.TEXTURE_MAG_FILTER, _gl.NEAREST);

--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -87,7 +87,9 @@ $3Dmol.GLViewer = (function() {
             col:config.col,
             rows:config.rows,
             cols:config.cols,
-            canvas:config.canvas
+            canvas:config.canvas,
+            containerWidth:WIDTH,
+            containerHeight:HEIGHT
         });
         renderer.domElement.style.width = "100%";
         renderer.domElement.style.height = "100%";
@@ -878,7 +880,7 @@ $3Dmol.GLViewer = (function() {
             HEIGHT = container.height();
             ASPECT = renderer.getAspect(WIDTH,HEIGHT);
             renderer.setSize(WIDTH, HEIGHT);
-            renderer.setFrameBufferSize(window.innerWidth, window.innerHeight);
+            renderer.setFrameBufferSize(WIDTH, HEIGHT);
             camera.aspect = ASPECT;
             camera.updateProjectionMatrix();
             show();


### PR DESCRIPTION
some errors happened because while integrating the newly created custom framebuffer with the normal behavior of the 3Dmol.js renderer, the dimensions were off in few cases, because the framebuffer was being initialized with the default size of the _gl.canvas before it was initialized to it's final size/dimensions