### PR TITLE
Fix python path in echo.cgi

### DIFF
--- a/echo.cgi
+++ b/echo.cgi
@@ -1,7 +1,6 @@
-#!/usr/bin/python
-#fetchs a file - workaround for cross site scripting prevention
-import cgi,requests,sys
-
+#!/usr/bin/env python2
+# fetchs a file - workaround for cross site scripting prevention
+import cgi, requests, sys
 
 form = cgi.FieldStorage()
 url = form["url"].value
@@ -11,4 +10,3 @@ print "Content-Type: text/text"
 print ""
 
 sys.stdout.write(response.text)
-


### PR DESCRIPTION
It's always better to use /usr/bin/env as the python executable might be
in various places.
Also specify that we want python2 as python3 won't work and nowadays it
is probably the default python interpreter.