### PR TITLE
Exposing renderer from $3Dmol.GLViewer

### DIFF
--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -664,6 +664,13 @@ $3Dmol.GLViewer = (function() {
         this.getCanvas = function() {
             return glDOM.get(0);
         };
+        
+        /**
+         * Return renderer element.
+         */
+        this.getRenderer = function() {
+            return renderer;
+        };
       /**
            * Set the duration of the hover delay
            * 


### PR DESCRIPTION
My suggestion is to expose the renderer to allow the creation and manipulation of custom textures and other custom features.