### PR TITLE
Add some missing documentation

### DIFF
--- a/3Dmol/3dmol.js
+++ b/3Dmol/3dmol.js
@@ -111,7 +111,7 @@ $.ajaxTransport(
  * Create and initialize an appropriate viewer at supplied HTML element using specification in config
  @function $3Dmol.createViewer
  * @param {Object | string} element - Either HTML element or string identifier
- * @param {ViewerSpec} config Viewer specification
+ * @param {ViewerSpec} config Viewer configuration
  * @param {Object} shared_viewer_resources shared resources between viewers' renderers
  * @return {$3Dmol.GLViewer} GLViewer, null if unable to instantiate WebGL
  * @example

--- a/3Dmol/glmodel.js
+++ b/3Dmol/glmodel.js
@@ -311,6 +311,7 @@ $3Dmol.GLModel = (function() {
          * @prop {number} scale - scale radius by specified amount
          * @prop {ColorschemeSpec} colorscheme - element based coloring
          * @prop {ColorSpec} color - fixed coloring, overrides colorscheme
+         * @prop {number} opacity - opacity, must be the same for all atoms in the model
          */
         /**
          * 
@@ -468,6 +469,7 @@ $3Dmol.GLModel = (function() {
          * @prop {number} linewidth *deprecated due to vanishing browser support* 
          * @prop {ColorschemeSpec} colorscheme - element based coloring
          * @prop {ColorSpec} color - fixed coloring, overrides colorscheme
+         * @prop {number} opacity - opacity, must be the same for all atoms in the model
          */
         
         // bonds - both atoms must match bond style
@@ -645,6 +647,7 @@ $3Dmol.GLModel = (function() {
          * @prop {number} scale - scale radius by specified amount
          * @prop {ColorschemeSpec} colorscheme - element based coloring
          * @prop {ColorSpec} color - fixed coloring, overrides colorscheme
+         * @prop {number} opacity - opacity, must be the same for all atoms in the model
          */
         
         //sphere drawing
@@ -875,6 +878,7 @@ $3Dmol.GLModel = (function() {
          * @prop {boolean} singleBonds - draw all bonds as single bonds if set
          * @prop {ColorschemeSpec} colorscheme - element based coloring
          * @prop {ColorSpec} color - fixed coloring, overrides colorscheme
+         * @prop {number} opacity - opacity, must be the same for all atoms in the model
          */
         
         // draws cylinders and small spheres (at bond radius)

--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -28,6 +28,7 @@
  * @param {boolean} config.antialias
  * @param {boolean} config.control_all
  * @param {boolean} config.orthographic
+ * @param {boolean} config.disableFog - Disable fog, default to false
  */
 $3Dmol.GLViewer = (function() {
     // private class variables
@@ -1959,12 +1960,12 @@ $3Dmol.GLViewer = (function() {
         };
 
         /**
-         * Set slab of view (contents outside of slab are clipped). M
+         * Set slab of view (contents outside of slab are clipped).
          * Must call render to update.
          * 
          * @function $3Dmol.GLViewer#setSlab
-         * @param {near}
-         * @param {far}
+         * @param {number} near near clipping plane distance
+         * @param {number} far far clipping plane distance
          */
         this.setSlab = function(near, far) {
             slabNear = near;
@@ -1974,8 +1975,10 @@ $3Dmol.GLViewer = (function() {
         /**
          * Get slab of view (contents outside of slab are clipped).
          * 
-         * @function $3Dmol.GLViewer#setSlab
-         * @return {Object} near/far
+         * @function $3Dmol.GLViewer#getSlab
+         * @return {Object}
+         *      @property {number} near - near clipping plane distance
+         *      @property {number} far - far clipping plane distance
          */
         this.getSlab = function() {
             return {near: slabNear, far: slabFar};
@@ -2900,16 +2903,25 @@ $3Dmol.GLViewer = (function() {
         
         /**
          * Return true if volumetric rendering is supported (WebGL 2.0 required)
+         *
+         * @function $3Dmol.GLViewer#hasVolumetricRender
+         * @return {boolean}
          */
         this.hasVolumetricRender = function() {
           return renderer.supportsVolumetric();  
         };
         
+        /**
+         * Enable/disable fog for content far from the camera
+         *
+         * @function $3Dmol.GLViewer#enableFog
+         * @param {boolean} fog whether to enable or disable the fog
+         */
         this.enableFog = function(fog){
-            if(fog){
-                scene.fog=new $3Dmol.Fog(bgColor, 100, 200);
-            }else{
-                config.disableFog=true;
+            if (fog) {
+                scene.fog = new $3Dmol.Fog(bgColor, 100, 200);
+            } else {
+                config.disableFog = true;
                 show();
             }
         };
@@ -3781,7 +3793,7 @@ $3Dmol.GLViewer = (function() {
          *            mesh
          * @param {Object}
          *            style
-         * @returns {Number} surfid
+         * @returns {number} surfid
          */
         this.addMesh = function(mesh) {
             var surfobj = {

--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -7,28 +7,7 @@
  * 
  * @constructor 
  * @param {Object} element HTML element within which to create viewer
- * @param {Object} config Object containing optional configuration for the viewer including:
- * @param {function} config.callback - Callback function to be immediately executed on this viewer
- * @param {Object} config.defaultcolors - Object defining default atom colors as atom => color property value pairs for all models within this viewer
- * @param {boolean} config.nomouse - Whether to disable mouse handlers
- * @param {string} config.backgroundColor - Color of the canvas' background
- * @param {number} config.camerax
- * @param {number} config.hoverDuration
- * @param {string} config.id - id of the canvas
- * @param {number} config.cartoonQuality - default 5
- * @param config.row
- * @param config.col
- * @param config.rows
- * @param config.cols
- * @param config.canvas
- * @param config.viewers
- * @param config.minimumZoomToDistance
- * @param config.lowerZoomLimit
- * @param config.upperZoomLimit
- * @param {boolean} config.antialias
- * @param {boolean} config.control_all
- * @param {boolean} config.orthographic
- * @param {boolean} config.disableFog - Disable fog, default to false
+ * @param {ViewerSpec} config Object containing optional configuration for the viewer
  */
 $3Dmol.GLViewer = (function() {
     // private class variables

--- a/3Dmol/specs.js
+++ b/3Dmol/specs.js
@@ -4,9 +4,27 @@
 /**
  * GLViewer input specification
  * @typedef ViewerSpec
- * @prop {Object} defaultcolors - map of elements to colors
- * @prop {boolean} nomouse - if true, disable handling of mouse events
- * @prop {ColorSpec} backgroundColor - color of background
+ * @prop {function} callback - Callback function to be immediately executed on this viewer
+ * @prop {Object} defaultcolors - Object defining default atom colors as atom => color property value pairs for all models within this viewer
+ * @prop {boolean} nomouse - Whether to disable disable handling of mouse events
+ * @prop {string} backgroundColor - Color of the canvas' background
+ * @prop {number} camerax
+ * @prop {number} hoverDuration
+ * @prop {string} id - id of the canvas
+ * @prop {number} cartoonQuality - default 5
+ * @prop {number} row
+ * @prop {number} col
+ * @prop {number} rows
+ * @prop {number} cols
+ * @prop canvas
+ * @prop viewers
+ * @prop minimumZoomToDistance
+ * @prop lowerZoomLimit
+ * @prop upperZoomLimit
+ * @prop {boolean} antialias
+ * @prop {boolean} control_all
+ * @prop {boolean} orthographic
+ * @prop {boolean} disableFog - Disable fog, default to false
  */
 
 /**


### PR DESCRIPTION
First commit adds documentation for slab & fog related options, as introduced in #247.

Second adds documentation for opacity as introduced in #111 

Third commit make sure the same configuration options are documented for `GLViewer` constructor & `createViewer`