### PR TITLE
Make a copy of the selection before evaluating them

### DIFF
--- a/3Dmol/glmodel.js
+++ b/3Dmol/glmodel.js
@@ -1993,7 +1993,35 @@ $3Dmol.GLModel = (function() {
          */
         this.selectedAtoms = function(sel, from) {
             var ret = [];
-            sel = sel || {};
+
+            // make a deep copy of an object. This does not support arbitrary
+            // javascript objects, but support enough for eveything that is
+            // used in selections: number, string, boolean, functions; as well
+            // as arrays and nested objects with values of the aformentioned
+            // types.
+            const deepCopy = function(object) {
+                const copy = {};
+                for (const key in object) {
+                    const item = object[key];
+                    if (Array.isArray(item)) {
+                        // handle array separatly from other typeof == "object"
+                        // elements
+                        copy[key] = [];
+                        for (let i=0; i<item.length; i++) {
+                            copy[key].push(deepCopy(item[i]));
+                        }
+                    } else if (typeof item === "object") {
+                        copy[key] = deepCopy(item);
+                    } else {
+                        copy[key] = item;
+                    }
+                }
+                return copy;
+            };
+            // make a copy of the selection to allow caching results without
+            // the possibility for the user to change the selection and this
+            // code not noticing the changes
+            sel = deepCopy(sel || {});
 
             if (!from) from = atoms;
             var aLength = from.length;

--- a/tests/auto/tests/testSelectionWithinAnd.js
+++ b/tests/auto/tests/testSelectionWithinAnd.js
@@ -1,9 +1,13 @@
 
-
 $3Dmol.download("cid:3672",viewer,{},function(){
+    let sel = {and: [{or: [{within:{sel:{elem:"O"}, distance: 2.5}}, {elem: "H"}]}, {within: {sel:{elem: "O"}, distance: 5}}]};
+    viewer.setStyle({}, {stick:{hidden:true},sphere:{hidden:true}});
+    viewer.setStyle(sel, {stick:{radius:0.2},sphere:{radius:0.5}});
+    if ('__cached_results' in sel.and) {
+        // fail the test if the user could access cached results
         viewer.setStyle({}, {stick:{hidden:true},sphere:{hidden:true}});
-        viewer.setStyle({and: [{or: [{within:{sel:{elem:"O"}, distance: 2.5}}, {elem: "H"}]}, {within: {sel:{elem: "O"}, distance: 5}}]}, {stick:{radius:0.2},sphere:{radius:0.5}});
-        viewer.zoomTo();
-        viewer.zoom(0.8);
-        viewer.render();
+    }
+    viewer.zoomTo();
+    viewer.zoom(0.8);
+    viewer.render();
 });


### PR DESCRIPTION
This ensures the user can never observe or break the caching done to improve evaluation time