### PR TITLE
Add the ability to set crystal matrix directly and use it for all unit cell operations

### DIFF
--- a/3Dmol/glmodel.js
+++ b/3Dmol/glmodel.js
@@ -1453,7 +1453,7 @@ $3Dmol.GLModel = (function() {
         };
         
         /**
-         * Returns crystallographic information if present.
+         * Set crystallographic information using three angles and three lengths
          *
          * @function $3Dmol.GLModel#setCrystData
          * @param {number} a - length of unit cell side
@@ -2220,7 +2220,6 @@ $3Dmol.GLModel = (function() {
          * 
          * @function $3Dmol.GLModel#removeAtoms
          * @param {type} badatoms - list of atoms
-         * @return {removeAtoms}
          */
         this.removeAtoms = function(badatoms) {
             molObj = null;

--- a/3Dmol/glmodel.js
+++ b/3Dmol/glmodel.js
@@ -2858,7 +2858,7 @@ $3Dmol.GLModel = (function() {
         this.addAtomSpecs = function(customAtomSpecs) {
             for (var i = 0; i < customAtomSpecs.length; i++) {
                 if (!GLModel.validAtomSelectionSpecs.hasOwnProperty(customAtomSpecs[i])) {
-                    GLModel.validAtomSelectionSpecs.push(customAtomSpecs[i]);
+                    GLModel.validAtomSelectionSpecs[customAtomSpecs[i]] = {};
                 }
             }
         };

--- a/3Dmol/glmodel.js
+++ b/3Dmol/glmodel.js
@@ -1445,9 +1445,16 @@ $3Dmol.GLModel = (function() {
          */
         this.getCrystData = function() {
             if (modelData.cryst) {
+                // add the matrix if it is missing
+                if (!modelData.cryst.matrix) {
+                    const cryst = modelData.cryst;
+                    modelData.cryst.matrix = $3Dmol.conversionMatrix3(
+                        cryst.a, cryst.b, cryst.c,
+                        cryst.alpha, cryst.beta, cryst.gamma
+                    );
+                }
                 return modelData.cryst;
-            }
-            else {
+            } else {
                 return null;
             }
         };
@@ -1473,8 +1480,12 @@ $3Dmol.GLModel = (function() {
             beta = beta || 90;
             gamma = gamma || 90;
             
-            modelData.cryst = {'a' : a, 'b' : b, 'c' : c, 
-                'alpha' : alpha, 'beta' : beta, 'gamma' : gamma};
+            const matrix = $3Dmol.conversionMatrix3(a, b, c, alpha, beta, gamma);
+            modelData.cryst = {
+                'a' : a, 'b' : b, 'c' : c, 
+                'alpha' : alpha, 'beta' : beta, 'gamma' : gamma,
+                'matrix': matrix
+            };
         };
         
         /**

--- a/3Dmol/glmodel.js
+++ b/3Dmol/glmodel.js
@@ -1489,6 +1489,27 @@ $3Dmol.GLModel = (function() {
         };
         
         /**
+         * Set the crystallographic matrix to the given matrix.
+         *
+         * This function removes `a`, `b`, `c`, `alpha`, `beta`, `gamma` from 
+         * the crystal data.
+         *
+         * @function $3Dmol.GLModel#setCrystMatrix
+         * @param {$3Dmol.Matrix3} matrix - unit cell matrix
+         */
+        this.setCrystMatrix = function(matrix) {
+            matrix = matrix || new $3Dmol.Matrix3(
+                1, 0, 0,
+                0, 1, 0,
+                0, 0, 1
+            );
+            
+            modelData.cryst = {
+                'matrix': matrix
+            };
+        };
+        
+        /**
          * Returns list of rotational/translational matrices if there is BIOMT data
          * Otherwise returns a list of just the ID matrix
          *

--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -2678,9 +2678,8 @@ $3Dmol.GLViewer = (function() {
             C = C || B;
             let cryst = model.getCrystData();
             if(cryst) {
-                let atoms = model.selectedAtoms({});
-                let cmat =  $3Dmol.conversionMatrix3(cryst.a, cryst.b, cryst.c, 
-                                            cryst.alpha, cryst.beta, cryst.gamma);
+                const atoms = model.selectedAtoms({});
+                const matrix = cryst.matrix;
                 let makeoff = function(I) {
                     //alternate around zero: 1,-1,2,-2...
                     if(I%2 == 0) return -I/2;
@@ -2692,7 +2691,7 @@ $3Dmol.GLViewer = (function() {
                         for(let k = 0; k < C; k++) {
                             if(i == 0 && j == 0 && k == 0) continue; //actual unit cell
                             let offset = new $3Dmol.Vector3(makeoff(i),makeoff(j),makeoff(k));
-                            offset.applyMatrix3(cmat);
+                            offset.applyMatrix3(matrix);
                             
                             let newatoms = [];
                             for(let a = 0; a < atoms.length; a++) {

--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -1022,6 +1022,8 @@ $3Dmol.GLViewer = (function() {
         var spinInterval;
         /**
          * Continuously rotate a scene around the specified axis.
+         *
+         * Call `$3Dmol.GLViewer.spin(false)` to stop spinning.
          * 
          * @function $3Dmol.GLViewer#spin
          * @param {string}
@@ -2478,11 +2480,11 @@ $3Dmol.GLViewer = (function() {
          * @prop {ArrowSpec} bstyle - arrow specification of "b" axis
          * @prop {ArrowSpec} cstyle - arrow specification of "c" axis
          * @prop {string} alabel - label for a axis
-         * @prop {LabelSpec} alabel - label style for a axis
+         * @prop {LabelSpec} alabelstyle - label style for a axis
          * @prop {string} blabel - label for b axis
-         * @prop {LabelSpec} blabel - label style for a axis         
+         * @prop {LabelSpec} blabelstyle - label style for b axis
          * @prop {string} clabel - label for c axis
-         * @prop {LabelSpec} clabel - label style for a axis
+         * @prop {LabelSpec} clabelstyle - label style for c axis
          
          */
         

--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -2539,10 +2539,9 @@ $3Dmol.GLViewer = (function() {
                     v = (Math.cos(alpha) - Math.cos(beta)*Math.cos(gamma))/Math.sin(gamma);
                     w = Math.sqrt(Math.max(0, 1-u*u-v*v));
             
-                    matrix = new $3Dmol.Matrix4(a, b*Math.cos(gamma), c*u, 0, 
-                                                    0, b*Math.sin(gamma), c*v, 0,
-                                                    0, 0,                 c*w, 0,
-                                                    0, 0,                 0,   1); 
+                    matrix = new $3Dmol.Matrix3(a, b*Math.cos(gamma), c*u, 
+                                                0, b*Math.sin(gamma), c*v,
+                                                0, 0,                 c*w); 
                 }  
          
                 var points = [  new $3Dmol.Vector3(0, 0, 0),
@@ -2555,7 +2554,7 @@ $3Dmol.GLViewer = (function() {
                                 new $3Dmol.Vector3(1, 1, 1)  ];
                             
                 for (var i = 0; i < points.length; i++) {
-                    points[i] = points[i].applyMatrix4(matrix);
+                    points[i] = points[i].applyMatrix3(matrix);
                 }
             
                 //draw box

--- a/3Dmol/labels.js
+++ b/3Dmol/labels.js
@@ -83,7 +83,7 @@ $3Dmol.Label.prototype = {
          * @prop {string} borderOpacity - color of border
          * @prop {ColorSpec} backgroundColor - color of background, default black
          * @prop {string} backgroundOpacity - opacity of background, default 1
-         * @prop {Object} position - x,y,z coordinates for label
+         * @prop {$3Dmol.Vector3} position - x,y,z coordinates for label
          * @prop {boolean} inFront - always put labels in from of model
          * @prop {boolean} showBackground - show background rounded rectangle, default true
          * @prop {boolean} fixed - sets the label to change with the model when zooming

--- a/3Dmol/parsers.js
+++ b/3Dmol/parsers.js
@@ -578,10 +578,11 @@ $3Dmol.Parsers = (function() {
       lattice.yVec = new Float32Array(lines[3].replace(/^\s+/, "").split(/\s+/));
       lattice.zVec = new Float32Array(lines[4].replace(/^\s+/, "").split(/\s+/));
 
-      var matrix = new $3Dmol.Matrix4(lattice.xVec[0], lattice.xVec[1], lattice.xVec[2], 0, 
-                                      lattice.yVec[0], lattice.yVec[1], lattice.yVec[2], 0,
-                                      lattice.zVec[0], lattice.zVec[1], lattice.zVec[2], 0,
-                                      0,                             0,               0, 1);
+      var matrix = new $3Dmol.Matrix3(
+          lattice.xVec[0], lattice.xVec[1], lattice.xVec[2],
+          lattice.yVec[0], lattice.yVec[1], lattice.yVec[2],
+          lattice.zVec[0], lattice.zVec[1], lattice.zVec[2]
+      );
       
       matrix.multiplyScalar(lattice.length);
       atoms.modelData = [{symmetries:[], cryst:{matrix:matrix}}];  

--- a/3Dmol/specs.js
+++ b/3Dmol/specs.js
@@ -78,7 +78,7 @@
   * @prop {boolean} doAssembly - boolean dictating weather or not to do assembly ; supported by mcif
   * @prop {boolean} duplicateAssemblyAtoms- Set to true if you wish to duplicate assembly atoms otherwise false ; supported by all formats with symmetries.  Not duplicating will result in faster rendering but it will not be possible to individually style symmetries.
   * @prop {boolean} normalizeAssembly - shift symmetry mates so their centroid is in the unit cell
-  * @prop {boolean} dontConnectDuplicatedAtoms - do not detect bonds between symmetries generated with duplicateAssemblyAtoms (cif only - other formats never make bonds between symmetries) 
+  * @prop {boolean} dontConnectDuplicatedAtoms - do not detect bonds between symmetries generated with duplicateAssemblyAtoms (cif only - other formats never make bonds between symmetries)
   * @prop {boolean} noSecondaryStructure - boolean dictating the presence of a secondary structure ; supported by pdb
   * @prop {boolean} noComputeSecondaryStructure - do not compute ss ; supported by pdb
   * @prop {string} altLoc -which alternate location to select, if present; '*' to load all ; supported by pdb
@@ -262,6 +262,8 @@
  * @prop {$3Dmol.Vector3} start
  * @prop {$3Dmol.Vector3} end
  * @prop {number} radius
+ * @prop {ColorSpec} color
+ * @prop {boolean} hidden
  * @prop {number} radiusRatio - ratio of arrow base to cylinder (1.618034 default)
  * @prop {number} mid - relative position of arrow base (0.618034 default)
  * @prop {number} midpos - position of arrow base in length units, if negative positioned from end instead of start.  Overrides mid.


### PR DESCRIPTION
Fixes #469 

This PR adds the ability to set `cryst.matrix` manually, use it for all unit cell operations and make sure it is set even when the user/parser only specified `a/b/c/alpha/beta/gama`.