### PR TITLE
Set eye separation value dynamically

### DIFF
--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -4366,30 +4366,16 @@ $3Dmol.GLViewer = (function() {
          * @function $3Dmol.GLViewer#setAutoEyeSeparation
          * @return {number} camera x position
          */
-        this.setAutoEyeSeparation = function(isright) {
+        this.setAutoEyeSeparation = function(isright, x) {          
             var dist = this.getPerceivedDistance();
-            if (isright || camera.position.x > 0) //setting a value of dist*tan(5)
-                camera.position.x = dist*Math.tan(Math.PI / 180.0 * 5.0);
-            else
-                camera.position.x = -dist*Math.tan(Math.PI / 180.0 * 5.0);
-            camera.lookAt(new $3Dmol.Vector3(0,0,rotationGroup.position.z));
-            return camera.position.x;
-        };
-	    
-	/**
-         * Used for setting a custom value of eyeSeparation. Created for calling by StereoViewer object
-         * @function $3Dmol.GLViewer#setEyeSeparation
-         * @return {number} camera x position
-         */
-        this.setEyeSeparation = function(x, isright) {
-          var dist = this.getPerceivedDistance();
-            if (isright || camera.position.x > 0) //setting a value of dist*tan(5)
+            if(!x) x = 5.0;
+            if (isright || camera.position.x > 0) //setting a value of dist*tan(x)
                 camera.position.x = dist*Math.tan(Math.PI / 180.0 * x);
             else
                 camera.position.x = -dist*Math.tan(Math.PI / 180.0 * x);
             camera.lookAt(new $3Dmol.Vector3(0,0,rotationGroup.position.z));
             return camera.position.x;
-        }
+        };
         
         /**
          * Set the default cartoon quality for newly created models.  Default is 5.

--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -4375,6 +4375,21 @@ $3Dmol.GLViewer = (function() {
             camera.lookAt(new $3Dmol.Vector3(0,0,rotationGroup.position.z));
             return camera.position.x;
         };
+	    
+	/**
+         * Used for setting a custom value of eyeSeparation. Created for calling by StereoViewer object
+         * @function $3Dmol.GLViewer#setEyeSeparation
+         * @return {number} camera x position
+         */
+        this.setEyeSeparation = function(x, isright) {
+          var dist = this.getPerceivedDistance();
+            if (isright || camera.position.x > 0) //setting a value of dist*tan(5)
+                camera.position.x = dist*Math.tan(Math.PI / 180.0 * x);
+            else
+                camera.position.x = -dist*Math.tan(Math.PI / 180.0 * x);
+            camera.lookAt(new $3Dmol.Vector3(0,0,rotationGroup.position.z));
+            return camera.position.x;
+        }
         
         /**
          * Set the default cartoon quality for newly created models.  Default is 5.


### PR DESCRIPTION
The function 'setAutoEyeSeparation' doesn't have the option to set the x value. Instead, it sets a fixed value of 5, which may not work for all users/glasses.