### PR TITLE
Add a setCameraParameters function to set FOV & CAMERA_Z

### DIFF
--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -603,12 +603,38 @@ $3Dmol.GLViewer = (function() {
                 viewer.zoom(10); //will not zoom all the way
                 viewer.render();
             });
-     */
+        */
         this.setZoomLimits = function(lower, upper) {
             if(typeof(lower) !== 'undefined') config.lowerZoomLimit = lower;
             if(upper) config.upperZoomLimit = upper;
             rotationGroup.position.z = adjustZoomToLimits(rotationGroup.position.z);
             show();
+        };
+
+        /**
+         * Set camera parameters (distance to the origin and field of view)
+         * 
+         * @function $3Dmol.GLViewer#setCameraParameters
+         * @param {parameters} - new camera parameters, with possible fields 
+         *                       being fov for the field of view and z for the 
+         *                       distance to the origin.
+         * @example
+          $.get("data/set1_122_complex.mol2", function(data) {
+                var m = viewer.addModel(data);
+                viewer.setCameraParameters({ fov: 10 , z: 300 });
+                viewer.render();
+            });
+        */
+        this.setCameraParameters = function(parameters) {
+            if (parameters.fov !== undefined) {
+                fov = parameters.fov;
+                camera.fov = fov;
+            }
+
+            if (parameters.z !== undefined) {
+                CAMERA_Z = parameters.z;
+                camera.z = CAMERA_Z;
+            }
         };
 
         var mouseButton;


### PR DESCRIPTION
I need to change these parameters as a workaround for #434: using a perspective camera with very small fov and distance to the object feels almost like a perspective camera. 

I tried to make this function generally useful to users of 3Dmol.js, let me know if there are better ways to do something like this!