### PR TITLE
Parsing of unit cell vectors in XYZ files

### DIFF
--- a/3Dmol/parsers.js
+++ b/3Dmol/parsers.js
@@ -728,14 +728,12 @@ $3Dmol.Parsers = (function() {
             var lattice_re = /Lattice\s*=\s*["\{\}]([^"\{\}]+)["\{\}]\s*/gi;
             var lattice_match = lattice_re.exec(lines[1]);
             if ((lattice_match != null) && (lattice_match.length > 1)) {
-                console.log(lattice_match[1])
                 var lattice = new Float32Array(lattice_match[1].split(/\s+/));
                 var matrix = new $3Dmol.Matrix3(
                     lattice[0], lattice[1], lattice[2],
                     lattice[3], lattice[4], lattice[5],
                     lattice[6], lattice[7], lattice[8]
                 );
-                console.log(matrix)
                 atoms.modelData = [{cryst:{matrix:matrix}}];
             }
 

--- a/3Dmol/parsers.js
+++ b/3Dmol/parsers.js
@@ -724,6 +724,21 @@ $3Dmol.Parsers = (function() {
                 break;
             if (lines.length < atomCount + 2)
                 break;
+
+            var lattice_re = /Lattice\s*=\s*["\{\}]([^"\{\}]+)["\{\}]\s*/gi;
+            var lattice_match = lattice_re.exec(lines[1]);
+            if ((lattice_match != null) && (lattice_match.length > 1)) {
+                console.log(lattice_match[1])
+                var lattice = new Float32Array(lattice_match[1].split(/\s+/));
+                var matrix = new $3Dmol.Matrix3(
+                    lattice[0], lattice[1], lattice[2],
+                    lattice[3], lattice[4], lattice[5],
+                    lattice[6], lattice[7], lattice[8]
+                );
+                console.log(matrix)
+                atoms.modelData = [{cryst:{matrix:matrix}}];
+            }
+
             var offset = 2;
             var start = atoms[atoms.length-1].length;
             var end = start + atomCount;


### PR DESCRIPTION
Added parsing of the Lattice parameter in extended XYZ files. This parameter contains the unit cell vectors. 
For parsing used regexp from the [ASE library](https://gitlab.com/ase/ase/-/blob/0683eaf282888448427f0951b341bbd1416807a5/ase/io/extxyz.py#L40).