### PR TITLE
avoid RangeError: Maximum call stack size exceeded when add click event to a long list of atoms

### DIFF
--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -273,9 +273,15 @@ $3Dmol.GLViewer = (function() {
                     let hoverable_atoms = model.selectedAtoms({
                         hoverable : true
                     });
-                    Array.prototype.push.apply(hoverables,hoverable_atoms);
+                    // Array.prototype.push.apply(hoverables,hoverable_atoms);
+                    for (let n = 0; n < hoverable_atoms.length; n++) {
+                        hoverables.push(hoverable_atoms[n]);
+                    }
 
-                    Array.prototype.push.apply(clickables, atoms); //add atoms into clickables
+                    // Array.prototype.push.apply(clickables, atoms); //add atoms into clickables
+                    for (let m = 0; m < atoms.length; m++) {
+                        clickables.push(atoms[m]);
+                    }
                     
                 }
             }


### PR DESCRIPTION
Hi,
At first his PR would not change anything. I encounter a rare issue that when I am trying to add clickable event to a long long list of atoms, I got this `RangeError: Maximum call stack size exceeded` error see below
![image](https://user-images.githubusercontent.com/102806/116183898-6c05b600-a6e4-11eb-9ad8-bf7a3cf7c88c.png)

by changing to a for loop instead of using array.apply seems fixes it.

ref: https://stackoverflow.com/questions/22123769/rangeerror-maximum-call-stack-size-exceeded-why

Thanks in advance for considering this PR.
