### PR TITLE
give label a default screenOffset to avoid warning message

### DIFF
--- a/3Dmol/labels.js
+++ b/3Dmol/labels.js
@@ -215,7 +215,7 @@ $3Dmol.Label.prototype = {
                 useScreenCoordinates : useScreen,
                 alignment : spriteAlignment,
                 depthTest : !inFront,
-                screenOffset : style.screenOffset
+                screenOffset : style.screenOffset || { x: 0, y: 0 },
             });
 
             this.sprite.scale.set(1,1,1);


### PR DESCRIPTION
Hi @dkoes, recent update of 3dmol.js prints warning message `$3Dmol.Material: 'screenOffset' parameter is undefined.`, 
you can see this warning by run the test file: testlabelscreenoffset.js
by giving a default value to avoid this.  thanks for your time.