### PR TITLE
Use the wheel event to control zoom

### DIFF
--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -861,7 +861,7 @@ $3Dmol.GLViewer = (function() {
             if (!nomouse) {
                 // user can request that the mouse handlers not be installed
                 glDOM.bind('mousedown touchstart', _handleMouseDown);
-                glDOM.bind('DOMMouseScroll mousewheel', _handleMouseScroll);
+                glDOM.bind('wheel', _handleMouseScroll);
                 glDOM.bind('mousemove touchmove', _handleMouseMove);
                 
                 glDOM.bind("contextmenu", function(ev) {


### PR DESCRIPTION
`mousewheel` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event), and firefox now support the standard `wheel` instead of requiring `DOMMouseScroll`

With the previous version, zooming in and out of a viewer on firefox (for example using the small viewer in https://3dmol.csb.pitt.edu/doc/index.html) would also scroll the page since the call to preventDefault was on a different event.