### PR TITLE
Wait for the DOM to be loaded to install jquery transport

### DIFF
--- a/packages/3Dmol/src/js/main/3dmol.js
+++ b/packages/3Dmol/src/js/main/3dmol.js
@@ -58,55 +58,59 @@ if (!String.prototype.endsWith) {
 *
 */
 
-// use this transport for "binary" data type
-$.ajaxTransport(
-               "+binary",
-               function(options, originalOptions, jqXHR) {
-                   // check for conditions and support for blob / arraybuffer response type
-                   if (window.FormData && ((options.dataType && (options.dataType == 'binary')) || 
-                           (options.data && ((window.ArrayBuffer && options.data instanceof ArrayBuffer) || 
-                                   (window.Blob && options.data instanceof Blob))))) {
-                       return {
-                           // create new XMLHttpRequest
-                           send : function(headers, callback) {
-                               // setup all variables
-                               var xhr = new XMLHttpRequest(), url = options.url, type = options.type, async = options.async || true,
-                               // blob or arraybuffer. Default is blob
-                               dataType = options.responseType || "blob", 
-                                           data = options.data || null, 
-                                           username = options.username || null, 
-                                           password = options.password || null;
 
-                               var xhrret = function() {
-                                   var data = {};
-                                   data[options.dataType] = xhr.response;
-                                   // make callback and send data
-                                   callback(xhr.status, xhr.statusText,
-                                           data,
-                                           xhr.getAllResponseHeaders());
-                               };
-                               
-                               xhr.addEventListener('load', xhrret);
-                               xhr.addEventListener('error', xhrret);
-                               xhr.addEventListener('abort', xhrret);
-                               
-                               xhr.open(type, url, async, username,
-                                       password);
+// only setup jquery ajax transport once the page is fully loaded
+document.addEventListener("DOMContentLoaded", function(){
+    // use this transport for "binary" data type
+    $.ajaxTransport(
+        "+binary",
+        function(options, originalOptions, jqXHR) {
+            // check for conditions and support for blob / arraybuffer response type
+            if (window.FormData && ((options.dataType && (options.dataType == 'binary')) || 
+                    (options.data && ((window.ArrayBuffer && options.data instanceof ArrayBuffer) || 
+                            (window.Blob && options.data instanceof Blob))))) {
+                return {
+                    // create new XMLHttpRequest
+                    send : function(headers, callback) {
+                        // setup all variables
+                        var xhr = new XMLHttpRequest(), url = options.url, type = options.type, async = options.async || true,
+                        // blob or arraybuffer. Default is blob
+                        dataType = options.responseType || "blob", 
+                                    data = options.data || null, 
+                                    username = options.username || null, 
+                                    password = options.password || null;
 
-                               // setup custom headers
-                               for ( var i in headers) {
-                                   xhr.setRequestHeader(i, headers[i]);
-                               }
+                        var xhrret = function() {
+                            var data = {};
+                            data[options.dataType] = xhr.response;
+                            // make callback and send data
+                            callback(xhr.status, xhr.statusText,
+                                    data,
+                                    xhr.getAllResponseHeaders());
+                        };
+                        
+                        xhr.addEventListener('load', xhrret);
+                        xhr.addEventListener('error', xhrret);
+                        xhr.addEventListener('abort', xhrret);
+                        
+                        xhr.open(type, url, async, username,
+                                password);
 
-                               xhr.responseType = dataType;
-                               xhr.send(data);
-                           },
-                           abort : function() {
-                               jqXHR.abort();
-                           }
-                       };
-                   }
-               });
+                        // setup custom headers
+                        for ( var i in headers) {
+                            xhr.setRequestHeader(i, headers[i]);
+                        }
+
+                        xhr.responseType = dataType;
+                        xhr.send(data);
+                    },
+                    abort : function() {
+                        jqXHR.abort();
+                    }
+                };
+            }
+        });
+});
 
     
 /**


### PR DESCRIPTION
I am trying to use 3Dmol inside jupyterlab, and jquery is not yet available when 3Dmol code is first loaded, which causes a crash. The simple fix is to delay until the DOM is fully loaded before installing the new jquery transport mechanism for binary files. 

Let me know if you think of a better way to do this!