### PR TITLE
Fix types not automatically found when importing in Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/3Dmol.js",
+  "types": "build/types/index.d.ts",
   "scripts": {
     "build": "webpack --config webpack.dev.js --mode development  && webpack --config webpack.prod.js --mode production && python3 tests/auto/generate_tests.py && npm run doc",
     "prepare": "npm run build",


### PR DESCRIPTION
When trying to import "3dmol" in our Typescript project, the typing files that the installed library comes with are not automatically found, and I get this error:

![image](https://user-images.githubusercontent.com/962412/214294161-c312aa25-58a4-4f92-86d0-24f8d5e21e10.png)

Simply adding this line to `package.json` resolves the error. 
```json
  "types": "build/types/index.d.ts",
```
