### PR TITLE
Add tolerance for touch clicks

### DIFF
--- a/src/GLViewer.ts
+++ b/src/GLViewer.ts
@@ -408,16 +408,22 @@ export class GLViewer {
         }
     };
 
-    // Determine if a positioned event is "close enough" to be considered a click event
-    // With a mouse the position should be exact.
-    // But allow some wiggle room when using touch interface.
-    private closeEnoughForClick(event, { allowWiggleRoom=null, tolerance=5}={}) {
-        var deltaX = Math.abs(this.getX(event) - this.mouseStartX);
-        var deltaY = Math.abs(this.getY(event) - this.mouseStartY);
-        let allowingWiggling = event.targetTouches;
-        if (allowWiggleRoom != null) allowingWiggling = allowWiggleRoom;
-        const toleranceToUse = allowingWiggling ? tolerance : 0;
-        return (deltaX <= toleranceToUse && deltaY <= toleranceToUse);
+    /**
+     * Determine if a positioned event is "close enough" to mouseStart to be considered a click.
+     * With a mouse, the position should be exact, but allow a slight delta for a touch interface.
+     * @param {Event} event
+     * @param {{ allowTolerance, tolerance: number }} options
+     */
+    private closeEnoughForClick(event, { allowTolerance=event.targetTouches, tolerance=5}={}) {
+        const x = this.getX(event);
+        const y = this.getY(event);
+        if (allowTolerance) {
+            const deltaX = Math.abs(x - this.mouseStartX);
+            const deltaY = Math.abs(y - this.mouseStartY);
+            return deltaX <= tolerance && deltaY <= tolerance;
+        } else {
+            return x === this.mouseStartX && y === this.mouseStartY;
+        }
     }
 
     private calcTouchDistance(ev) { // distance between first two

--- a/src/GLViewer.ts
+++ b/src/GLViewer.ts
@@ -411,10 +411,12 @@ export class GLViewer {
     // Determine if a positioned event is "close enough" to be considered a click event
     // With a mouse the position should be exact.
     // But allow some wiggle room when using touch interface.
-    private closeEnoughForClick(event, tolerance: number=5) {
+    private closeEnoughForClick(event, { allowWiggleRoom=null, tolerance=5}={}) {
         var deltaX = Math.abs(this.getX(event) - this.mouseStartX);
         var deltaY = Math.abs(this.getY(event) - this.mouseStartY);
-        const toleranceToUse = event.targetTouches ? tolerance : 0;
+        let allowingWiggling = event.targetTouches;
+        if (allowWiggleRoom != null) allowingWiggling = allowWiggleRoom;
+        const toleranceToUse = allowingWiggling ? tolerance : 0;
         return (deltaX <= toleranceToUse && deltaY <= toleranceToUse);
     }
 

--- a/src/GLViewer.ts
+++ b/src/GLViewer.ts
@@ -408,6 +408,16 @@ export class GLViewer {
         }
     };
 
+    // Determine if a positioned event is "close enough" to be considered a click event
+    // With a mouse the position should be exact.
+    // But allow some wiggle room when using touch interface.
+    private closeEnoughForClick(event, tolerance: number=5) {
+        var deltaX = Math.abs(this.getX(event) - this.mouseStartX);
+        var deltaY = Math.abs(this.getY(event) - this.mouseStartY);
+        const toleranceToUse = event.targetTouches ? tolerance : 0;
+        return (deltaX <= toleranceToUse && deltaY <= toleranceToUse);
+    }
+
     private calcTouchDistance(ev) { // distance between first two
         // fingers
         var xdiff = ev.targetTouches[0].pageX -
@@ -883,7 +893,7 @@ export class GLViewer {
         if (this.isDragging && this.scene) { //saw mousedown, haven't moved
             var x = this.getX(ev);
             var y = this.getY(ev);
-            if (x == this.mouseStartX && y == this.mouseStartY) {
+            if (this.closeEnoughForClick(ev)) {
                 var offset = this.canvasOffset();
                 var mouseX = ((x - offset.left) / this.WIDTH) * 2 - 1;
                 var mouseY = -((y - offset.top) / this.HEIGHT) * 2 + 1;


### PR DESCRIPTION
It can be difficult to keep your finger in exactly the right place when using a touch interface.
This PR adds a `closeEnoughForClick` which allows a delta when comparing the position against the mouseStart.

By default, it requires exact position for mouse and allows tolerance for touch events (events with targetTouches), but the caller can also specify if they want to allow or disallow the tolerance.

This function will be used in a followup PR for contextmenu events.