### PR TITLE
Remove trailing whitespace in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "engines": {
     "npm": ">=8.11",
-    "node": ">=16.16.0"      
+    "node": ">=16.16.0"
   },
   "dependencies": {
     "iobuffer": "^5.3.1",


### PR DESCRIPTION
Hello,

My editor is showing trailing whitespaces and:

![2023-03-24-021652_311x122_scrot](https://user-images.githubusercontent.com/3043706/227400203-8d865880-bc43-4544-92aa-32f5aab2ff91.png)

So here you are, a little PR ;)

Best,
~Nico