### PR TITLE
Fix SDF parsing to avoid overflow error

### DIFF
--- a/src/parsers/SDF.ts
+++ b/src/parsers/SDF.ts
@@ -54,7 +54,7 @@ var parseV2000 = function (lines: any, options: ParserOptionsSpec) {
     }
     if (options.multimodel) {
       if (!options.onemol) atoms.push([]);
-      while (lines[offset] !== "$$$$") offset++;
+      while (lines[offset] !== "$$$$" && offset < lines.length) offset++;
       lines.splice(0, ++offset);
     } else {
       break;
@@ -148,7 +148,7 @@ var parseV3000 = function (lines: any, options: ParserOptionsSpec) {
       if (!options.onemol) {
         atoms.push([]);
       }
-      while (lines[offset] !== "$$$$") {
+      while (lines[offset] !== "$$$$" && offset < lines.length) {
         offset++;
       }
       lines.splice(0, ++offset);


### PR DESCRIPTION
The while loop should stop executing its body in two scenarios:

- When it finds the string "$$$$" at the offset index within the lines array.
- When the offset index reaches or exceeds the length of the lines array.

The second check was not being performed.

For reference, the last frame in this file did not have the final delimiter. Not sure why, but it shouldn't hang parsing in any event.

```
$$$$
M0041

Created by GaussView 6.0.16
 16 16  0  0  0  0  0  0  0  0  0    0
   -1.3437   -0.3857   -0.2426 C   0  0  0  0  0  0  0  0  0  0  0  0
   -2.4242   -0.2833   -0.2771 H   0  0  0  0  0  0  0  0  0  0  0  0
   -1.1147   -1.4484   -0.3272 H   0  0  0  0  0  0  0  0  0  0  0  0
   -0.6553    0.3753   -1.3686 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.2543    0.9300   -2.0784 H   0  0  0  0  0  0  0  0  0  0  0  0
    0.6553    0.3753   -1.3686 C   0  0  0  0  0  0  0  0  0  0  0  0
    1.2543    0.9300   -2.0784 H   0  0  0  0  0  0  0  0  0  0  0  0
    1.3437   -0.3857   -0.2426 C   0  0  0  0  0  0  0  0  0  0  0  0
    1.1147   -1.4484   -0.3272 H   0  0  0  0  0  0  0  0  0  0  0  0
    2.4242   -0.2833   -0.2771 H   0  0  0  0  0  0  0  0  0  0  0  0
    0.7801    0.1352    1.1077 C   0  0  0  0  0  0  0  0  0  0  0  0
    1.1441    1.1477    1.2604 H   0  0  0  0  0  0  0  0  0  0  0  0
    1.1586   -0.4709    1.9260 H   0  0  0  0  0  0  0  0  0  0  0  0
   -0.7801    0.1352    1.1077 C   0  0  0  0  0  0  0  0  0  0  0  0
   -1.1441    1.1477    1.2604 H   0  0  0  0  0  0  0  0  0  0  0  0
   -1.1586   -0.4709    1.9260 H   0  0  0  0  0  0  0  0  0  0  0  0
  1  2  1  0  0  0  0
  1  3  1  0  0  0  0
  1  4  4  0  0  0  0
  1 14  1  0  0  0  0
  4  5  1  0  0  0  0
  4  6  4  0  0  0  0
  6  7  1  0  0  0  0
  6  8  4  0  0  0  0
  8  9  1  0  0  0  0
  8 10  1  0  0  0  0
  8 11  1  0  0  0  0
 11 12  1  0  0  0  0
 11 13  1  0  0  0  0
 11 14  4  0  0  0  0
 14 15  1  0  0  0  0
 14 16  1  0  0  0  0
M  END
```