### PR TITLE
Add strict equality operator to TS files src/*

### DIFF
--- a/src/GLDraw.ts
+++ b/src/GLDraw.ts
@@ -224,7 +224,7 @@ export namespace GLDraw {
                             if (Math.abs(vertex.z) < 1e-5)
                                 vertex.z = 0;
 
-                            if (cap == CAP.FLAT) {
+                            if (cap === CAP.FLAT) {
                                 n = new Vector3(0, Math.cos(thetaStart + v * thetaLength), 0);
                                 n.normalize();
                             }
@@ -302,9 +302,9 @@ export namespace GLDraw {
         let getcap = function(c: CAP|string): CAP {
             if(typeof c === "string") {
                 let s = <string>c;
-                if(s.toLowerCase() == 'flat') {
+                if(s.toLowerCase() === 'flat') {
                     return CAP.FLAT;
-                } else if(s.toLowerCase() == 'round') {
+                } else if(s.toLowerCase() === 'round') {
                     return CAP.ROUND;
                 } else {
                     return CAP.NONE;

--- a/src/GLModel.ts
+++ b/src/GLModel.ts
@@ -166,7 +166,7 @@ export class GLModel {
      */
     private getRadiusFromStyle(atom:AtomSpec, style:SphereStyleSpec|ClickSphereStyleSpec|CrossStyleSpec) {
         var r = this.defaultSphereRadius;
-        if (typeof (style.radius) !== "undefined")
+        if (style.radius !== undefined)
             r = style.radius;
         else if (GLModel.vdwRadii[atom.elem])
             r = GLModel.vdwRadii[atom.elem];
@@ -177,7 +177,7 @@ export class GLModel {
                 r = GLModel.vdwRadii[e];
         }
 
-        if (typeof (style.scale) !== "undefined")
+        if (style.scale !== undefined)
             r *= style.scale;
         return r;
     };
@@ -403,10 +403,10 @@ export class GLModel {
                     continue;
                 }
                 if (bstyle.singleBond) singleBond = true;
-                if (typeof (bstyle.color1) !== "undefined") {
+                if (bstyle.color1 !== undefined) {
                     c1 = CC.color(bstyle.color1) as Color;
                 }
-                if (typeof (bstyle.color2) !== "undefined") {
+                if (bstyle.color2 !== undefined) {
                     c2 = CC.color(bstyle.color2) as Color;
                 }
             }
@@ -839,10 +839,10 @@ export class GLModel {
                     }
                     if (bstyle.radius) bondR = bstyle.radius;
                     if (bstyle.singleBond) singleBond = true;
-                    if (typeof (bstyle.color1) !== "undefined") {
+                    if (bstyle.color1 !== undefined) {
                         C1 = CC.color(bstyle.color1) as Color;
                     }
-                    if (typeof (bstyle.color2) !== "undefined") {
+                    if (bstyle.color2 !== undefined) {
                         C2 = CC.color(bstyle.color2) as Color;
                     }
                 }
@@ -1141,7 +1141,7 @@ export class GLModel {
                 this.drawBondLines(atom, atoms, lineGeometries);
                 this.drawBondSticks(atom, atoms, stickGeometry);
 
-                if (typeof (atom.style.cartoon) !== "undefined" && !atom.style.cartoon.hidden) {
+                if (atom.style.cartoon !== undefined && !atom.style.cartoon.hidden) {
                     //gradient color scheme range
                     if (atom.style.cartoon.color === "spectrum" && typeof (atom.resi) === "number" && !atom.hetflag) {
                         if (atom.resi < range[0])
@@ -1209,7 +1209,7 @@ export class GLModel {
             var stickMaterial = null;
             var ballMaterial = null;
             var balls = stickGeometry.sphereGeometry;
-            if (!balls || typeof (balls.vertices) === 'undefined' || balls.vertices === 0) balls = null; //no balls
+            if (!balls || balls.vertices === undefined || balls.vertices === 0) balls = null; //no balls
 
             //Initialize buffers in geometry
             stickGeometry.initTypedArrays();
@@ -1410,7 +1410,7 @@ export class GLModel {
      */
     public getSymmetries() {
 
-        if (typeof (this.modelData.symmetries) === 'undefined') {
+        if (this.modelData.symmetries === undefined) {
             this.modelData.symmetries = [this.idMatrix];
         }
         return this.modelData.symmetries;
@@ -1423,7 +1423,7 @@ export class GLModel {
      *
      */
     public setSymmetries(list) {
-        if (typeof (list) === "undefined") { //delete sym data
+        if (list === undefined) { //delete sym data
             this.modelData.symmetries = [this.idMatrix];
         }
         else {
@@ -1818,7 +1818,7 @@ export class GLModel {
      * @return {boolean}
      */
     public atomIsSelected(atom:AtomSpec, sel?:AtomSelectionSpec) {
-        if (typeof (sel) === "undefined")
+        if (sel === undefined)
             return true; // undef gets all
         var invert = !!sel.invert;
         var ret = true;
@@ -1852,7 +1852,7 @@ export class GLModel {
             else if (key === "properties" && atom[key]) {
                 for (var propkey in sel.properties) {
                     if (propkey.startsWith("__cache")) continue;
-                    if (typeof (atom.properties[propkey]) === 'undefined') {
+                    if (atom.properties[propkey] === undefined) {
                         ret = false;
                         break;
                     }
@@ -1865,7 +1865,7 @@ export class GLModel {
             else if (sel.hasOwnProperty(key) && !GLModel.ignoredKeys.has(key) && !key.startsWith('__cache')) {
 
                 // if something is in sel, atom must have it
-                if (typeof (atom[key]) === "undefined") {
+                if (atom[key] === undefined) {
                     ret = false;
                     break;
                 }
@@ -2104,9 +2104,9 @@ export class GLModel {
         // mapping from old index to new index
         var i;
         for (i = 0; i < newatoms.length; i++) {
-            if (typeof (newatoms[i].index) === "undefined")
+            if (newatoms[i].index === undefined)
                 newatoms[i].index = i;
-            if (typeof (newatoms[i].serial) === "undefined")
+            if (newatoms[i].serial === undefined)
                 newatoms[i].serial = i;
             indexmap[newatoms[i].index] = start + i;
         }
@@ -2121,14 +2121,14 @@ export class GLModel {
             a.bondOrder = [];
             a.model = this.id;
             a.style = a.style || deepCopy(GLModel.defaultAtomStyle);
-            if (typeof (a.color) === "undefined")
+            if (a.color === undefined)
                 a.color = this.ElementColors[a.elem] || this.defaultColor;
             // copy over all bonds contained in selection,
             // updating indices appropriately
             var nbonds = olda.bonds ? olda.bonds.length : 0;
             for (var j = 0; j < nbonds; j++) {
                 var neigh = indexmap[olda.bonds[j]];
-                if (typeof (neigh) !== "undefined") {
+                if (neigh !== undefined) {
                     a.bonds.push(neigh);
                     a.bondOrder.push(olda.bondOrder ? olda.bondOrder[j] : 1);
                 }
@@ -2195,7 +2195,7 @@ export class GLModel {
      */
     public setStyle(sel:AtomSelectionSpec|AtomStyleSpec|string, style?:AtomStyleSpec|string, add?) {
 
-        if (typeof (style) === 'undefined' && typeof (add) === 'undefined') {
+        if (style === undefined && add === undefined) {
             //if a single argument is provided, assume it is a style and select all
             style = sel as AtomStyleSpec|string;
             sel = {};
@@ -2353,7 +2353,7 @@ export class GLModel {
             this.molObj = null; // force rebuild
         for (var i = 0; i < atoms.length; i++) {
             var a = atoms[i];
-            if (typeof (colors[a.elem]) !== "undefined") {
+            if (colors?.[a.elem] !== undefined) {
                 a.color = colors[a.elem];
             }
         }
@@ -2371,7 +2371,7 @@ export class GLModel {
         if (atoms.length > 0)
             this.molObj = null; // force rebuild
 
-        if (typeof scheme === 'string' && typeof (Gradient.builtinGradients[scheme]) !== "undefined") {
+        if (typeof scheme === 'string' && Gradient.builtinGradients[scheme] !== undefined) {
             scheme = new Gradient.builtinGradients[scheme]();
         }
         scheme = scheme as Gradient;
@@ -2575,9 +2575,9 @@ export class GLModel {
         for (var i = 0; i < atoms.length; i++) {
             var a = atoms[i];
             var label = null;
-            if (typeof (a[prop]) !== 'undefined') {
+            if (a[prop] !== undefined) {
                 label = String(a[prop]);
-            } else if (typeof (a.properties[prop]) !== 'undefined') {
+            } else if (a.properties?.[prop] !== undefined) {
                 label = String(a.properties[prop]);
             }
 
@@ -2839,10 +2839,10 @@ export class GLModel {
             }
         }
 
-        if (typeof (Parsers[format]) === "undefined") {
+        if (Parsers[format] === undefined) {
             // let someone provide a file name and get format from extension
             format = format.split('.').pop();
-            if (typeof (Parsers[format]) === "undefined") {
+            if (Parsers[format] === undefined) {
                 console.log("Unknown format: " + format);
                 // try to guess correct format from data contents
                 if (data instanceof Uint8Array) {

--- a/src/GLModel.ts
+++ b/src/GLModel.ts
@@ -115,7 +115,7 @@ export class GLModel {
     // return true if a and b represent the same style
     static sameObj(a, b) {
         if (a && b)
-            return JSON.stringify(a) == JSON.stringify(b);
+            return JSON.stringify(a) === JSON.stringify(b);
         else
             return a == b;
     };
@@ -166,7 +166,7 @@ export class GLModel {
      */
     private getRadiusFromStyle(atom:AtomSpec, style:SphereStyleSpec|ClickSphereStyleSpec|CrossStyleSpec) {
         var r = this.defaultSphereRadius;
-        if (typeof (style.radius) != "undefined")
+        if (typeof (style.radius) !== "undefined")
             r = style.radius;
         else if (GLModel.vdwRadii[atom.elem])
             r = GLModel.vdwRadii[atom.elem];
@@ -177,7 +177,7 @@ export class GLModel {
                 r = GLModel.vdwRadii[e];
         }
 
-        if (typeof (style.scale) != "undefined")
+        if (typeof (style.scale) !== "undefined")
             r *= style.scale;
         return r;
     };
@@ -403,10 +403,10 @@ export class GLModel {
                     continue;
                 }
                 if (bstyle.singleBond) singleBond = true;
-                if (typeof (bstyle.color1) != "undefined") {
+                if (typeof (bstyle.color1) !== "undefined") {
                     c1 = CC.color(bstyle.color1) as Color;
                 }
-                if (typeof (bstyle.color2) != "undefined") {
+                if (typeof (bstyle.color2) !== "undefined") {
                     c2 = CC.color(bstyle.color2) as Color;
                 }
             }
@@ -724,7 +724,7 @@ export class GLModel {
         var negateColor = function (c) {
             //set sign bit
             var n = -c;
-            if (n == 0) n = -0.0001;
+            if (n === 0) n = -0.0001;
             return n;
         };
 
@@ -839,10 +839,10 @@ export class GLModel {
                     }
                     if (bstyle.radius) bondR = bstyle.radius;
                     if (bstyle.singleBond) singleBond = true;
-                    if (typeof (bstyle.color1) != "undefined") {
+                    if (typeof (bstyle.color1) !== "undefined") {
                         C1 = CC.color(bstyle.color1) as Color;
                     }
-                    if (typeof (bstyle.color2) != "undefined") {
+                    if (typeof (bstyle.color2) !== "undefined") {
                         C2 = CC.color(bstyle.color2) as Color;
                     }
                 }
@@ -903,7 +903,7 @@ export class GLModel {
                     var r, p1a, p1b, p2a, p2b;
                     v = this.getSideBondV(atom, atom2, i);
 
-                    if (atom.bondOrder[i] == 2) {
+                    if (atom.bondOrder[i] === 2) {
                         r = bondR * doubleBondScale;
 
                         v.multiplyScalar(r * 1.5);
@@ -953,7 +953,7 @@ export class GLModel {
                             }
                         }
                     }
-                    else if (atom.bondOrder[i] == 3) {
+                    else if (atom.bondOrder[i] === 3) {
                         r = bondR * tripleBondScale;
                         v.cross(dir);
                         v.normalize();
@@ -1033,11 +1033,11 @@ export class GLModel {
             if (atom.bondStyles && atom.bondStyles[i]) {
                 bstyle = atom.bondStyles[i];
                 if (bstyle.singleBond) singleBond = true;
-                if (bstyle.radius && bstyle.radius != atomBondR) {
+                if (bstyle.radius && bstyle.radius !== atomBondR) {
                     differentradii = true;
                 }
             }
-            if (singleBond || atom.bondOrder[i] == 1) {
+            if (singleBond || atom.bondOrder[i] === 1) {
                 numsinglebonds++;
             }
         }
@@ -1045,7 +1045,7 @@ export class GLModel {
         if (differentradii) { //jmol style double/triple bonds - no sphere
             if (numsinglebonds > 0) drawSphere = true; //unless needed as a cap
         }
-        else if (numsinglebonds == 0 && (atom.bonds.length > 0 || style.showNonBonded)) {
+        else if (numsinglebonds === 0 && (atom.bonds.length > 0 || style.showNonBonded)) {
             drawSphere = true;
         }
 
@@ -1209,7 +1209,7 @@ export class GLModel {
             var stickMaterial = null;
             var ballMaterial = null;
             var balls = stickGeometry.sphereGeometry;
-            if (!balls || typeof (balls.vertices) === 'undefined' || balls.vertices == 0) balls = null; //no balls
+            if (!balls || typeof (balls.vertices) === 'undefined' || balls.vertices === 0) balls = null; //no balls
 
             //Initialize buffers in geometry
             stickGeometry.initTypedArrays();
@@ -1410,7 +1410,7 @@ export class GLModel {
      */
     public getSymmetries() {
 
-        if (typeof (this.modelData.symmetries) == 'undefined') {
+        if (typeof (this.modelData.symmetries) === 'undefined') {
             this.modelData.symmetries = [this.idMatrix];
         }
         return this.modelData.symmetries;
@@ -1423,7 +1423,7 @@ export class GLModel {
      *
      */
     public setSymmetries(list) {
-        if (typeof (list) == "undefined") { //delete sym data
+        if (typeof (list) === "undefined") { //delete sym data
             this.modelData.symmetries = [this.idMatrix];
         }
         else {
@@ -1586,7 +1586,7 @@ export class GLModel {
         for (var i = start; i < end; i++) {
             var newAtoms = [];
             var currframe = this.frames.length;
-            if (i == 0 && !arrowSpec) { //still need to calculate if drawing arrows
+            if (i === 0 && !arrowSpec) { //still need to calculate if drawing arrows
                 this.frames.push(this.atoms);
                 continue;
             }
@@ -1670,7 +1670,7 @@ export class GLModel {
             this.box = null;
         }
 
-        if (this.frames.length == 0) { //first call
+        if (this.frames.length === 0) { //first call
             for (let i = 0; i < parsedAtoms.length; i++) {
                 if (parsedAtoms[i].length != 0)
                     this.frames.push(parsedAtoms[i]);
@@ -1718,7 +1718,7 @@ export class GLModel {
     private propertyMatches(atomval, val) {
         if (atomval == val) {
             return true;
-        } else if (typeof (val) == 'string' && typeof (atomval) == 'number') {
+        } else if (typeof (val) === 'string' && typeof (atomval) === 'number') {
             //support numerical integer ranges, e.g. resi: 3-7
             var match = val.match(/(-?\d+)\s*-\s*(-?\d+)/);
             if (match) {
@@ -1741,7 +1741,7 @@ export class GLModel {
     // as arrays and nested objects with values of the aformentioned
     // types.
     private static deepCopyAndCache(selobject, model) {
-        if (typeof selobject != 'object' || selobject == null) return selobject;
+        if (typeof selobject !== 'object' || selobject == null) return selobject;
         if (selobject.__cache_created) return selobject; //already done
         const copy: any = {};
         for (const key in selobject) {
@@ -1753,7 +1753,7 @@ export class GLModel {
                 for (let i = 0; i < item.length; i++) {
                     copy[key].push(GLModel.deepCopyAndCache(item[i], model));
                 }
-            } else if (typeof item === "object" && key != "properties" && key != "model") {
+            } else if (typeof item === "object" && key !== "properties" && key !== "model") {
                 copy[key] = GLModel.deepCopyAndCache(item, model);
             } else {
                 copy[key] = item;
@@ -1761,7 +1761,7 @@ export class GLModel {
 
             //create caches of expensive selection types - the cache
             //stores the atoms matching the selection type
-            if (key == "and" || key == "or") {
+            if (key === "and" || key === "or") {
                 // create a list of sets of matching atoms indexes for
                 // each sub-selection
                 const results = [];
@@ -1773,7 +1773,7 @@ export class GLModel {
                     results.push(set);
                 }
 
-                if (key == "and") {
+                if (key === "and") {
                     // get the intersection of two sets
                     const intersect = function (first, other) {
                         const result = new Set();
@@ -1791,7 +1791,7 @@ export class GLModel {
                     }
                     copy[key].__cached_results = intersection;
 
-                } else if (key == "or") {
+                } else if (key === "or") {
                     const union = new Set();
                     for (const set of results) {
                         for (const elem of set) {
@@ -1823,8 +1823,8 @@ export class GLModel {
         var invert = !!sel.invert;
         var ret = true;
         for (var key in sel) {
-            if (key == "and" || key == "or" || key == "not") {  //boolean operators
-                if (key == "not") {
+            if (key === "and" || key === "or" || key === "not") {  //boolean operators
+                if (key === "not") {
                     if (this.atomIsSelected(atom, sel[key])) {
                         ret = false;
                         break;
@@ -1849,7 +1849,7 @@ export class GLModel {
                     break;
                 }
             }
-            else if (key == "properties" && atom[key]) {
+            else if (key === "properties" && atom[key]) {
                 for (var propkey in sel.properties) {
                     if (propkey.startsWith("__cache")) continue;
                     if (typeof (atom.properties[propkey]) === 'undefined') {
@@ -1873,7 +1873,7 @@ export class GLModel {
                 if (key === "bonds") {
                     //special case counting number of bonds, for selecting nonbonded mostly
                     var val = sel[key];
-                    if (val != atom.bonds.length) {
+                    if (val !== atom.bonds.length) {
                         ret = false;
                         break;
                     }
@@ -2104,9 +2104,9 @@ export class GLModel {
         // mapping from old index to new index
         var i;
         for (i = 0; i < newatoms.length; i++) {
-            if (typeof (newatoms[i].index) == "undefined")
+            if (typeof (newatoms[i].index) === "undefined")
                 newatoms[i].index = i;
-            if (typeof (newatoms[i].serial) == "undefined")
+            if (typeof (newatoms[i].serial) === "undefined")
                 newatoms[i].serial = i;
             indexmap[newatoms[i].index] = start + i;
         }
@@ -2121,14 +2121,14 @@ export class GLModel {
             a.bondOrder = [];
             a.model = this.id;
             a.style = a.style || deepCopy(GLModel.defaultAtomStyle);
-            if (typeof (a.color) == "undefined")
+            if (typeof (a.color) === "undefined")
                 a.color = this.ElementColors[a.elem] || this.defaultColor;
             // copy over all bonds contained in selection,
             // updating indices appropriately
             var nbonds = olda.bonds ? olda.bonds.length : 0;
             for (var j = 0; j < nbonds; j++) {
                 var neigh = indexmap[olda.bonds[j]];
-                if (typeof (neigh) != "undefined") {
+                if (typeof (neigh) !== "undefined") {
                     a.bonds.push(neigh);
                     a.bondOrder.push(olda.bondOrder ? olda.bondOrder[j] : 1);
                 }
@@ -2195,7 +2195,7 @@ export class GLModel {
      */
     public setStyle(sel:AtomSelectionSpec|AtomStyleSpec|string, style?:AtomStyleSpec|string, add?) {
 
-        if (typeof (style) === 'undefined' && typeof (add) == 'undefined') {
+        if (typeof (style) === 'undefined' && typeof (add) === 'undefined') {
             //if a single argument is provided, assume it is a style and select all
             style = sel as AtomStyleSpec|string;
             sel = {};
@@ -2371,7 +2371,7 @@ export class GLModel {
         if (atoms.length > 0)
             this.molObj = null; // force rebuild
 
-        if (typeof scheme === 'string' && typeof (Gradient.builtinGradients[scheme]) != "undefined") {
+        if (typeof scheme === 'string' && typeof (Gradient.builtinGradients[scheme]) !== "undefined") {
             scheme = new Gradient.builtinGradients[scheme]();
         }
         scheme = scheme as Gradient;
@@ -2440,7 +2440,7 @@ export class GLModel {
             atomJSON.x = atom.x;
             atomJSON.y = atom.y;
             atomJSON.z = atom.z;
-            if (atom.elem != "C") {
+            if (atom.elem !== "C") {
                 atomJSON.l = atom.elem;
             }
             if (includeStyles) {
@@ -2469,7 +2469,7 @@ export class GLModel {
                     e: secondAtom
                 };
                 let bondOrder = atom.bondOrder[b];
-                if (bondOrder != 1) {
+                if (bondOrder !== 1) {
                     bond.o = bondOrder;
                 }
                 out.b.push(bond);
@@ -2575,9 +2575,9 @@ export class GLModel {
         for (var i = 0; i < atoms.length; i++) {
             var a = atoms[i];
             var label = null;
-            if (typeof (a[prop]) != 'undefined') {
+            if (typeof (a[prop]) !== 'undefined') {
                 label = String(a[prop]);
-            } else if (typeof (a.properties[prop]) != 'undefined') {
+            } else if (typeof (a.properties[prop]) !== 'undefined') {
                 label = String(a.properties[prop]);
             }
 
@@ -2789,7 +2789,7 @@ export class GLModel {
         var values = []; // this will contain the all the float values in the
         // file.
         var counter = 0;
-        if (format == "pdb") {
+        if (format === "pdb") {
             var index = data.indexOf("\nATOM");
             while (index != -1) {
                 while (data.slice(index, index + 5) == "\nATOM" ||
@@ -2807,15 +2807,15 @@ export class GLModel {
                 index = data.indexOf("\nATOM", index);
             }
 
-        } else if (format == "netcdf") {
+        } else if (format === "netcdf") {
             var reader = new NetCDFReader(data);
             values = [].concat.apply([], reader.getDataVariable('coordinates'));
 
-        } else if (format == "array" || Array.isArray(data)) {
+        } else if (format === "array" || Array.isArray(data)) {
             return data.flat(2);
         } else {
             let index = data.indexOf("\n"); // remove the first line containing title
-            if (format == 'inpcrd') {
+            if (format === 'inpcrd') {
                 index = data.indexOf("\n", index + 1); //remove second line w/#atoms
             }
 
@@ -2839,10 +2839,10 @@ export class GLModel {
             }
         }
 
-        if (typeof (Parsers[format]) == "undefined") {
+        if (typeof (Parsers[format]) === "undefined") {
             // let someone provide a file name and get format from extension
             format = format.split('.').pop();
-            if (typeof (Parsers[format]) == "undefined") {
+            if (typeof (Parsers[format]) === "undefined") {
                 console.log("Unknown format: " + format);
                 // try to guess correct format from data contents
                 if (data instanceof Uint8Array) {

--- a/src/GLModel.ts
+++ b/src/GLModel.ts
@@ -115,7 +115,7 @@ export class GLModel {
     // return true if a and b represent the same style
     static sameObj(a, b) {
         if (a && b)
-            return JSON.stringify(a) === JSON.stringify(b);
+            return JSON.stringify(a) == JSON.stringify(b);
         else
             return a == b;
     };

--- a/src/GLShape.ts
+++ b/src/GLShape.ts
@@ -582,7 +582,7 @@ export class GLShape {
         }
 
         var color = customSpec.color;
-        if (typeof (color) == 'undefined') {
+        if (typeof (color) === 'undefined') {
             color = shape.color;
         }
         color = CC.color(color);
@@ -604,7 +604,7 @@ export class GLShape {
      * @returns {undefined}
      */
     static updateFromStyle(shape: GLShape, stylespec: ShapeSpec) {
-        if (typeof (stylespec.color) != 'undefined') {
+        if (typeof (stylespec.color) !== 'undefined') {
             shape.color = stylespec.color || new Color();
             if (!(stylespec.color instanceof Color))
                 shape.color = CC.color(stylespec.color);
@@ -615,11 +615,11 @@ export class GLShape {
         //opacity is the preferred nomenclature, support alpha for backwards compat
         shape.opacity = stylespec.alpha ? clamp(stylespec.alpha, 0.0,
             1.0) : 1.0;
-        if (typeof (stylespec.opacity) != 'undefined') {
+        if (typeof (stylespec.opacity) !== 'undefined') {
             shape.opacity = clamp(stylespec.opacity, 0.0, 1.0);
         }
         shape.side = (stylespec.side !== undefined) ? stylespec.side : DoubleSide;
-        shape.linewidth = typeof (stylespec.linewidth) == 'undefined' ? 1 : stylespec.linewidth;
+        shape.linewidth = typeof (stylespec.linewidth) === 'undefined' ? 1 : stylespec.linewidth;
         // Click handling
         shape.clickable = stylespec.clickable ? true : false;
         shape.callback = makeFunction(stylespec.callback);
@@ -783,19 +783,19 @@ export class GLShape {
 
         //dimensions may be scalar or vector quantities
         var w: XYZ;
-        if (typeof (dim.w) == "number") {
+        if (typeof (dim.w) === "number") {
             w = { x: dim.w, y: 0, z: 0 };
         } else {
             w = dim.w;
         }
         var h: XYZ;
-        if (typeof (dim.h) == "number") {
+        if (typeof (dim.h) === "number") {
             h = { x: 0, y: dim.h, z: 0 };
         } else {
             h = dim.h;
         }
         var d: XYZ;
-        if (typeof (dim.d) == "number") {
+        if (typeof (dim.d) === "number") {
             d = { x: 0, y: 0, z: dim.d };
         } else {
             d = dim.d;
@@ -924,7 +924,7 @@ export class GLShape {
         } else {
             end = new Vector3(cylinderSpec.end.x,
                 cylinderSpec.end.y || 0, cylinderSpec.end.z || 0);
-            if (typeof (end.x) == 'undefined') end.x = 3; //show something even if undefined
+            if (typeof (end.x) === 'undefined') end.x = 3; //show something even if undefined
         }
         var radius = cylinderSpec.radius || 0.1;
         var color = CC.color(cylinderSpec.color);
@@ -964,7 +964,7 @@ export class GLShape {
         else {
             end = new Vector3(cylinderSpec.end.x,
                 cylinderSpec.end.y || 0, cylinderSpec.end.z || 0);
-            if (typeof (end.x) == 'undefined') end.x = 3; //show something even if undefined
+            if (typeof (end.x) === 'undefined') end.x = 3; //show something even if undefined
         }
 
         var radius = cylinderSpec.radius || 0.1;
@@ -1009,8 +1009,8 @@ export class GLShape {
 
         curveSpec.points = curveSpec.points || [];
         curveSpec.smooth = curveSpec.smooth || 10;
-        if (typeof (curveSpec.fromCap) == "undefined") curveSpec.fromCap = 2;
-        if (typeof (curveSpec.toCap) == "undefined") curveSpec.toCap = 2;
+        if (typeof (curveSpec.fromCap) === "undefined") curveSpec.fromCap = 2;
+        if (typeof (curveSpec.toCap) === "undefined") curveSpec.toCap = 2;
 
         //subdivide into smoothed spline points
         var points = subdivide_spline(curveSpec.points, curveSpec.smooth);
@@ -1103,7 +1103,7 @@ export class GLShape {
         } else {
             end = new Vector3(lineSpec.end.x,
                 lineSpec.end.y || 0, lineSpec.end.z || 0);
-            if (typeof (end.x) == 'undefined') end.x = 3; //show something even if undefined
+            if (typeof (end.x) === 'undefined') end.x = 3; //show something even if undefined
         }
 
         var geoGroup = this.geo.updateGeoGroup(2);
@@ -1178,7 +1178,7 @@ export class GLShape {
         } else {
             arrowSpec.end = new Vector3(arrowSpec.end.x,
                 arrowSpec.end.y || 0, arrowSpec.end.z || 0);
-            if (typeof (arrowSpec.end.x) == 'undefined') arrowSpec.end.x = 3; //show something even if undefined
+            if (typeof (arrowSpec.end.x) === 'undefined') arrowSpec.end.x = 3; //show something even if undefined
         }
 
         arrowSpec.radius = arrowSpec.radius || 0.1;
@@ -1390,7 +1390,7 @@ export class GLShape {
         var len2 = total.distanceTo(maxv);
         this.boundingSphere.center = total;
         this.boundingSphere.radius = Math.max(len1, len2);
-        if (typeof callback == "function")
+        if (typeof callback === "function")
             callback();
     };
 
@@ -1434,7 +1434,7 @@ export class GLShape {
             this.geo.setUpWireframe();
         }
 
-        if (typeof (this.color) != 'undefined')
+        if (typeof (this.color) !== 'undefined')
             GLShape.updateColor(this.geo, this.color);
 
         this.shapeObj = new Object3D();

--- a/src/GLShape.ts
+++ b/src/GLShape.ts
@@ -582,7 +582,7 @@ export class GLShape {
         }
 
         var color = customSpec.color;
-        if (typeof (color) === 'undefined') {
+        if (color === undefined) {
             color = shape.color;
         }
         color = CC.color(color);
@@ -604,7 +604,7 @@ export class GLShape {
      * @returns {undefined}
      */
     static updateFromStyle(shape: GLShape, stylespec: ShapeSpec) {
-        if (typeof (stylespec.color) !== 'undefined') {
+        if (stylespec.color !== undefined) {
             shape.color = stylespec.color || new Color();
             if (!(stylespec.color instanceof Color))
                 shape.color = CC.color(stylespec.color);
@@ -615,11 +615,11 @@ export class GLShape {
         //opacity is the preferred nomenclature, support alpha for backwards compat
         shape.opacity = stylespec.alpha ? clamp(stylespec.alpha, 0.0,
             1.0) : 1.0;
-        if (typeof (stylespec.opacity) !== 'undefined') {
+        if (stylespec.opacity !== undefined) {
             shape.opacity = clamp(stylespec.opacity, 0.0, 1.0);
         }
         shape.side = (stylespec.side !== undefined) ? stylespec.side : DoubleSide;
-        shape.linewidth = typeof (stylespec.linewidth) === 'undefined' ? 1 : stylespec.linewidth;
+        shape.linewidth = stylespec.linewidth === undefined ? 1 : stylespec.linewidth;
         // Click handling
         shape.clickable = stylespec.clickable ? true : false;
         shape.callback = makeFunction(stylespec.callback);
@@ -924,7 +924,7 @@ export class GLShape {
         } else {
             end = new Vector3(cylinderSpec.end.x,
                 cylinderSpec.end.y || 0, cylinderSpec.end.z || 0);
-            if (typeof (end.x) === 'undefined') end.x = 3; //show something even if undefined
+            if (end.x === undefined) end.x = 3; //show something even if undefined
         }
         var radius = cylinderSpec.radius || 0.1;
         var color = CC.color(cylinderSpec.color);
@@ -964,7 +964,7 @@ export class GLShape {
         else {
             end = new Vector3(cylinderSpec.end.x,
                 cylinderSpec.end.y || 0, cylinderSpec.end.z || 0);
-            if (typeof (end.x) === 'undefined') end.x = 3; //show something even if undefined
+            if (end.x === undefined) end.x = 3; //show something even if undefined
         }
 
         var radius = cylinderSpec.radius || 0.1;
@@ -1009,8 +1009,8 @@ export class GLShape {
 
         curveSpec.points = curveSpec.points || [];
         curveSpec.smooth = curveSpec.smooth || 10;
-        if (typeof (curveSpec.fromCap) === "undefined") curveSpec.fromCap = 2;
-        if (typeof (curveSpec.toCap) === "undefined") curveSpec.toCap = 2;
+        if (curveSpec.fromCap === undefined) curveSpec.fromCap = 2;
+        if (curveSpec.toCap === undefined) curveSpec.toCap = 2;
 
         //subdivide into smoothed spline points
         var points = subdivide_spline(curveSpec.points, curveSpec.smooth);
@@ -1103,7 +1103,7 @@ export class GLShape {
         } else {
             end = new Vector3(lineSpec.end.x,
                 lineSpec.end.y || 0, lineSpec.end.z || 0);
-            if (typeof (end.x) === 'undefined') end.x = 3; //show something even if undefined
+            if (end.x === undefined) end.x = 3; //show something even if undefined
         }
 
         var geoGroup = this.geo.updateGeoGroup(2);
@@ -1178,7 +1178,7 @@ export class GLShape {
         } else {
             arrowSpec.end = new Vector3(arrowSpec.end.x,
                 arrowSpec.end.y || 0, arrowSpec.end.z || 0);
-            if (typeof (arrowSpec.end.x) === 'undefined') arrowSpec.end.x = 3; //show something even if undefined
+            if (arrowSpec.end?.x === undefined) arrowSpec.end.x = 3; //show something even if undefined
         }
 
         arrowSpec.radius = arrowSpec.radius || 0.1;
@@ -1434,7 +1434,7 @@ export class GLShape {
             this.geo.setUpWireframe();
         }
 
-        if (typeof (this.color) !== 'undefined')
+        if (this.color !== undefined)
             GLShape.updateColor(this.geo, this.color);
 
         this.shapeObj = new Object3D();

--- a/src/GLViewer.ts
+++ b/src/GLViewer.ts
@@ -115,7 +115,7 @@ export class GLViewer {
     private getRect() {
         let div = this.container;
         let rect = div.getBoundingClientRect();
-        if (rect.width == 0 && rect.height == 0 && div.style.display === 'none') {
+        if (rect.width === 0 && rect.height === 0 && div.style.display === 'none') {
             let oldpos = div.style.position;
             let oldvis = div.style.visibility;
             div.style.display = 'block';
@@ -337,7 +337,7 @@ export class GLViewer {
         if (intersects.length) {
             var selected = intersects[0].clickable;
             if (selected.callback !== undefined) {
-                if (typeof (selected.callback) != "function") {
+                if (typeof (selected.callback) !== "function") {
                     selected.callback = makeFunction(selected.callback);
                 }
                 if (typeof (selected.callback) === "function") {
@@ -365,7 +365,7 @@ export class GLViewer {
     private setHover(selected, event?, intersects?) {
         if (this.current_hover == selected) return;
         if (this.current_hover) {
-            if (typeof (this.current_hover.unhover_callback) != "function") {
+            if (typeof (this.current_hover.unhover_callback) !== "function") {
                 this.current_hover.unhover_callback = makeFunction(this.current_hover.unhover_callback);
             }
             this.current_hover.unhover_callback(this.current_hover, this._viewer, event, this.container, intersects);
@@ -373,7 +373,7 @@ export class GLViewer {
         this.current_hover = selected;
 
         if (selected && selected.hover_callback !== undefined) {
-            if (typeof (selected.hover_callback) != "function") {
+            if (typeof (selected.hover_callback) !== "function") {
                 selected.hover_callback = makeFunction(selected.hover_callback);
             }
             if (typeof (selected.hover_callback) === "function") {
@@ -385,7 +385,7 @@ export class GLViewer {
 
     //checks for selection intersects on hover
     private handleHoverSelection(mouseX, mouseY, event) {
-        if (this.hoverables.length == 0) return;
+        if (this.hoverables.length === 0) return;
         let intersects = this.targetedObjects(mouseX, mouseY, this.hoverables);
         if (intersects.length) {
             var selected = intersects[0].clickable;
@@ -400,7 +400,7 @@ export class GLViewer {
     //sees if the mouse is still on the object that invoked a hover event and if not then the unhover callback is called
     private handleHoverContinue(mouseX: number, mouseY: number) {
         let intersects = this.targetedObjects(mouseX, mouseY, this.hoverables);
-        if (intersects.length == 0 || intersects[0] === undefined) {
+        if (intersects.length === 0 || intersects[0] === undefined) {
             this.setHover(null);
         }
         if (intersects[0] !== undefined && intersects[0].clickable !== this.current_hover) {
@@ -476,7 +476,7 @@ export class GLViewer {
             var r = this.rows - Math.floor(rely / height) - 1;
             var c = Math.floor(relx / width);
 
-            if (r != this.row || c != this.col)
+            if (r !== this.row || c !== this.col)
                 return false;
         }
         return true;
@@ -507,8 +507,8 @@ export class GLViewer {
     private static slerp(v0: Quaternion, v1: Quaternion, t: number) {
         // Compute the cosine of the angle between the two vectors.
         //dot product
-        if (t == 1) return v1.clone();
-        else if (t == 0) return v0.clone();
+        if (t === 1) return v1.clone();
+        else if (t === 0) return v0.clone();
         let dot = v0.x * v1.x + v0.y * v1.y + v0.z * v1.z + v0.w * v1.w;
         if (dot > 0.9995) {
             // If the inputs are too close for comfort, linearly interpolate
@@ -567,13 +567,13 @@ export class GLViewer {
         this.nomouse = this.config.nomouse;
         this.bgColor = 0;
         this.config.backgroundColor = this.config.backgroundColor || "#ffffff";
-        if (typeof (this.config.backgroundColor) != 'undefined') {
+        if (typeof (this.config.backgroundColor) !== 'undefined') {
             this.bgColor = CC.color(this.config.backgroundColor).getHex();
         }
         this.config.backgroundAlpha = this.config.backgroundAlpha == undefined ? 1.0 : this.config.backgroundAlpha;
 
         this.camerax = 0;
-        if (typeof (this.config.camerax) != 'undefined') {
+        if (typeof (this.config.camerax) !== 'undefined') {
             this.camerax = parseFloat(this.config.camerax);
         }
         this._viewer = this;
@@ -654,7 +654,7 @@ export class GLViewer {
         if (!Array.isArray(objects)) { //assume selection object
             objects = this.selectedAtoms(objects);
         }
-        if (objects.length == 0) return [];
+        if (objects.length === 0) return [];
         this.raycaster.setFromCamera(mouse, this.camera);
         return this.raycaster.intersectObjects(this.modelGroup, objects);
     };
@@ -877,7 +877,7 @@ export class GLViewer {
         this.touchHold = true;
         this.touchDistanceStart = 0;
         if (ev.targetTouches &&
-            ev.targetTouches.length == 2) {
+            ev.targetTouches.length === 2) {
             this.touchDistanceStart = this.calcTouchDistance(ev);
         }
         this.cq = this.rotationGroup.quaternion.clone();
@@ -889,7 +889,7 @@ export class GLViewer {
         let self = this;
         setTimeout(function () {
             if (ev.targetTouches) {
-                if (self.touchHold == true) {
+                if (self.touchHold === true) {
                     // console.log('Touch hold', x,y);
                     self.glDOM = self.renderer.domElement;
                     self.glDOM.dispatchEvent(new Event('contextmenu'));
@@ -979,7 +979,7 @@ export class GLViewer {
                     }, "image/png");
                 }));
                 framecnt += 1;
-                if (framecnt == nframes) {
+                if (framecnt === nframes) {
                     viewer.viewChangeCallback = oldcb;
 
                     Promise.all(bufpromise).then((buffers) => {
@@ -1094,15 +1094,15 @@ export class GLViewer {
         var dx = (x - this.mouseStartX) / this.WIDTH;
         var dy = (y - this.mouseStartY) / this.HEIGHT;
         // check for pinch
-        if (this.touchDistanceStart != 0 &&
+        if (this.touchDistanceStart !== 0 &&
             ev.targetTouches &&
-            ev.targetTouches.length == 2) {
+            ev.targetTouches.length === 2) {
             var newdist = this.calcTouchDistance(ev);
             // change to zoom
             mode = 2;
             dy = (newdist - this.touchDistanceStart) * 2 / (this.WIDTH + this.HEIGHT);
         } else if (ev.targetTouches &&
-            ev.targetTouches.length == 3) {
+            ev.targetTouches.length === 3) {
             // translate
             mode = 1;
         }
@@ -1111,16 +1111,16 @@ export class GLViewer {
         dy *= ratioY;
         var r = Math.hypot(dx, dy);
         var scaleFactor;
-        if (mode == 3 || (this.mouseButton == 3 && ev.ctrlKey)) { // Slab
+        if (mode === 3 || (this.mouseButton == 3 && ev.ctrlKey)) { // Slab
             this.slabNear = this.cslabNear + dx * 100;
             this.slabFar = this.cslabFar - dy * 100;
-        } else if (mode == 2 || this.mouseButton == 3 || ev.shiftKey) { // Zoom
+        } else if (mode === 2 || this.mouseButton == 3 || ev.shiftKey) { // Zoom
             scaleFactor = (this.CAMERA_Z - this.rotationGroup.position.z) * 0.85;
             if (scaleFactor < 80)
                 scaleFactor = 80;
             this.rotationGroup.position.z = this.cz + dy * scaleFactor;
             this.rotationGroup.position.z = this.adjustZoomToLimits(this.rotationGroup.position.z);
-        } else if (mode == 1 || this.mouseButton == 2 || ev.ctrlKey) { // Translate
+        } else if (mode === 1 || this.mouseButton == 2 || ev.ctrlKey) { // Translate
             var t = this.screenOffsetToModel(ratioX * (x - this.mouseStartX), ratioY * (y - this.mouseStartY));
             this.modelGroup.position.addVectors(this.currentModelPos, t);
 
@@ -1204,7 +1204,7 @@ export class GLViewer {
      *
      */
     public setBackgroundColor(hex: ColorSpec, a: number) {
-        if (typeof (a) == "undefined") {
+        if (typeof (a) === "undefined") {
             a = 1.0;
         }
         else if (a < 0 || a > 1.0) {
@@ -1316,7 +1316,7 @@ export class GLViewer {
             this.initContainer(this.container);
             regen = true;
         }
-        if (this.WIDTH == 0 || this.HEIGHT == 0) {
+        if (this.WIDTH === 0 || this.HEIGHT === 0) {
             if (this.animated) this._viewer.pauseAnimate();
         } else if (this.animated) {
             this._viewer.resumeAnimate();
@@ -1357,13 +1357,13 @@ export class GLViewer {
      */
     public getModel(id?: number | GLModel) {
         if (id === undefined) {
-            return this.models.length == 0 ? null : this.models[this.models.length - 1];
+            return this.models.length === 0 ? null : this.models[this.models.length - 1];
         }
         if (id instanceof GLModel) {
             return id;
         }
         if (!(id in this.models)) {
-            if (this.models.length == 0)
+            if (this.models.length === 0)
                 return null;
             else
                 return this.models[this.models.length - 1]; //get last model if no (or invalid) id specified
@@ -1387,9 +1387,9 @@ export class GLViewer {
      */
     public spin(axis, speed: number = 1) {
         clearInterval(this.spinInterval);
-        if (typeof axis == 'undefined')
+        if (typeof axis === 'undefined')
             axis = 'y';
-        if (typeof axis == "boolean") {
+        if (typeof axis === "boolean") {
             if (!axis)
                 return;
             else
@@ -1471,7 +1471,7 @@ export class GLViewer {
             if (mpos) {
                 delta.mpos = mpos.clone().sub(curr.mpos).multiplyScalar(frac);
             }
-            if (typeof (rz) != 'undefined' && rz != null) {
+            if (typeof (rz) !== 'undefined' && rz != null) {
                 delta.rz = frac * (rz - curr.rz);
             }
             if (rot) {
@@ -1630,7 +1630,7 @@ export class GLViewer {
         this.rotationGroup.quaternion.y = arg[5];
         this.rotationGroup.quaternion.z = arg[6];
         this.rotationGroup.quaternion.w = arg[7];
-        if (typeof (arg[8]) != "undefined") {
+        if (typeof (arg[8]) !== "undefined") {
             this.rotationGroup.position.x = arg[8];
             this.rotationGroup.position.y = arg[9];
         }
@@ -1676,7 +1676,7 @@ export class GLViewer {
         }
 
         for (i = 0; i < this.labels.length; i++) {
-            if (this.labels[i] && typeof (this.labels[i].frame) != 'undefined' && this.labels[i].frame >= 0) { //exists and has frame specifier
+            if (this.labels[i] && typeof (this.labels[i].frame) !== 'undefined' && this.labels[i].frame >= 0) { //exists and has frame specifier
                 this.modelGroup.remove(this.labels[i].sprite);
                 if (this.viewer_frame < 0 || this.labels[i].frame == this.viewer_frame) {
                     this.modelGroup.add(this.labels[i].sprite);
@@ -2539,7 +2539,7 @@ export class GLViewer {
         if (spec.hasOwnProperty("x") && spec.hasOwnProperty("y") && spec.hasOwnProperty("z"))
             return spec as XYZ;
         var atoms = this.getAtomsFromSel(spec);
-        if (atoms.length == 0)
+        if (atoms.length === 0)
             return { x: 0, y: 0, z: 0 };
 
         var extent = getExtent(atoms);
@@ -2963,14 +2963,14 @@ export class GLViewer {
             const matrix = cryst.matrix;
             let makeoff = function (I) {
                 //alternate around zero: 1,-1,2,-2...
-                if (I % 2 == 0) return -I / 2;
+                if (I % 2 === 0) return -I / 2;
                 else return Math.ceil(I / 2);
             };
 
             for (let i = 0; i < A; i++) {
                 for (let j = 0; j < B; j++) {
                     for (let k = 0; k < C; k++) {
-                        if (i == 0 && j == 0 && k == 0) continue; //actual unit cell
+                        if (i === 0 && j === 0 && k === 0) continue; //actual unit cell
                         let offset = new Vector3(makeoff(i), makeoff(j), makeoff(k));
                         offset.applyMatrix3(matrix);
 
@@ -3302,7 +3302,7 @@ export class GLViewer {
                 self.setFrame(currFrame)
                     .then(function () {
                         currFrame += inc;
-                        inc *= (((currFrame % (mostFrames - 1)) == 0) ? -1 : 1);
+                        inc *= (((currFrame % (mostFrames - 1)) === 0) ? -1 : 1);
                         resolve();
                     });
             }
@@ -3314,7 +3314,7 @@ export class GLViewer {
                 //we no longer exist as part of the DOM
                 self.stopAnimate();
             }
-            else if (++displayCount == displayMax || !self.isAnimated()) {
+            else if (++displayCount === displayMax || !self.isAnimated()) {
                 timer.cancel();
                 self.animationTimers.delete(timer);
                 self.decAnim();
@@ -3759,7 +3759,7 @@ export class GLViewer {
 
         for (let i = 0; i < atomlist.length; i++) {
             var atom = atomlist[i];
-            if (typeof (atom) == "undefined")
+            if (typeof (atom) === "undefined")
                 continue;
 
             if (atom.x < extent[0][0] || atom.x > extent[1][0])
@@ -3902,7 +3902,7 @@ export class GLViewer {
         for (let i = 0, il = atoms.length; i < il; i++) {
             var atom = atoms[i];
             if (atom) {
-                if (typeof (atom.surfaceColor) != "undefined") {
+                if (typeof (atom.surfaceColor) !== "undefined") {
                     colors[i] = atom.surfaceColor;
                 } else if (atom.color) // map from atom
                     colors[i] = CC.color(atom.color);
@@ -4028,7 +4028,7 @@ export class GLViewer {
 
         ps.buildboundary();
 
-        if (type == SurfaceType.SES || type == SurfaceType.MS) {
+        if (type === SurfaceType.SES || type === SurfaceType.MS) {
             ps.fastdistancemap();
             ps.boundingatom(false);
             ps.fillvoxelswaals(atoms, extendedAtoms);
@@ -4135,13 +4135,13 @@ export class GLViewer {
         let self = this;
         let type: SurfaceType | 0 = SurfaceType.VDW;
 
-        if (typeof stype == "string") {
+        if (typeof stype === "string") {
             if (GLViewer.surfaceTypeMap[stype.toUpperCase()] !== undefined)
                 type = GLViewer.surfaceTypeMap[stype];
             else {
                 console.log("Surface type : " + stype + " is not recognized");
             }
-        } else if(typeof stype == "number") {
+        } else if(typeof stype === "number") {
             type = stype;
         }
 
@@ -4321,7 +4321,7 @@ export class GLViewer {
 
                         //    console.log("async mesh generation " + (+new Date() - time) + "ms");
                         cnt++;
-                        if (cnt == extents.length) {
+                        if (cnt === extents.length) {
                             surfobj.done = true;
                             releaseMemory();
                             resolve(surfid); //caller of helper will resolve callback if present
@@ -4401,7 +4401,7 @@ export class GLViewer {
         this.surfaces[surfid] = surfobj;
         promise.surfid = surfid;
 
-        if (surfacecallback && typeof (surfacecallback) == "function") {
+        if (surfacecallback && typeof (surfacecallback) === "function") {
             promise.then(function (surfid) {
                 surfacecallback(surfid);
             });
@@ -4562,7 +4562,7 @@ export class GLViewer {
         sel = sel || {};
         var atoms = this.getAtomsFromSel(sel);
 
-        if (typeof (props) == "function") {
+        if (typeof (props) === "function") {
             for (let a = 0, numa = atoms.length; a < numa; a++) {
                 let atom = atoms[a];
                 props(atom);
@@ -4779,7 +4779,7 @@ export function createStereoViewer(element) {
 
     var methods = Object.getOwnPropertyNames(this.glviewer1.__proto__) //get all methods of glviewer object
         .filter(function (property) {
-            return typeof that.glviewer1[property] == 'function';
+            return typeof that.glviewer1[property] === 'function';
         });
 
     for (var i = 0; i < methods.length; i++) { //create methods of the same name

--- a/src/GLViewer.ts
+++ b/src/GLViewer.ts
@@ -337,9 +337,8 @@ export class GLViewer {
         if (intersects.length) {
             var selected = intersects[0].clickable;
             if (selected.callback !== undefined) {
-                if (typeof (selected.callback) !== "function") {
-                    selected.callback = makeFunction(selected.callback);
-                }
+                if (typeof (selected.callback) !== "function") selected.callback = makeFunction(selected.callback);
+                
                 if (typeof (selected.callback) === "function") {
                     selected.callback(selected, this._viewer, event, this.container, intersects);
                 }
@@ -385,7 +384,7 @@ export class GLViewer {
 
     //checks for selection intersects on hover
     private handleHoverSelection(mouseX, mouseY, event) {
-        if (this.hoverables.length === 0) return;
+        if (this.hoverables.length == 0) return;
         let intersects = this.targetedObjects(mouseX, mouseY, this.hoverables);
         if (intersects.length) {
             var selected = intersects[0].clickable;
@@ -400,7 +399,7 @@ export class GLViewer {
     //sees if the mouse is still on the object that invoked a hover event and if not then the unhover callback is called
     private handleHoverContinue(mouseX: number, mouseY: number) {
         let intersects = this.targetedObjects(mouseX, mouseY, this.hoverables);
-        if (intersects.length === 0 || intersects[0] === undefined) {
+        if (intersects.length == 0 || intersects[0] === undefined) {
             this.setHover(null);
         }
         if (intersects[0] !== undefined && intersects[0].clickable !== this.current_hover) {
@@ -623,7 +622,7 @@ export class GLViewer {
 
         window.addEventListener("resize", this.resize.bind(this));
 
-        if (window.ResizeObserver !== undefined) {
+        if (typeof window.ResizeObserver !== "undefined") {
             this.divwatcher = new window.ResizeObserver(this.resize.bind(this));
             this.divwatcher.observe(this.container);
         }
@@ -1316,7 +1315,7 @@ export class GLViewer {
             this.initContainer(this.container);
             regen = true;
         }
-        if (this.WIDTH === 0 || this.HEIGHT === 0) {
+        if (this.WIDTH == 0 || this.HEIGHT == 0) {
             if (this.animated) this._viewer.pauseAnimate();
         } else if (this.animated) {
             this._viewer.resumeAnimate();
@@ -1387,8 +1386,7 @@ export class GLViewer {
      */
     public spin(axis, speed: number = 1) {
         clearInterval(this.spinInterval);
-        if (axis === undefined)
-            axis = 'y';
+        if (axis === undefined) axis = 'y';
         if (typeof axis === "boolean") {
             if (!axis)
                 return;
@@ -1630,7 +1628,7 @@ export class GLViewer {
         this.rotationGroup.quaternion.y = arg[5];
         this.rotationGroup.quaternion.z = arg[6];
         this.rotationGroup.quaternion.w = arg[7];
-        if (arg[8] !== undefined) {
+        if (typeof arg[8] !== "undefined") {
             this.rotationGroup.position.x = arg[8];
             this.rotationGroup.position.y = arg[9];
         }
@@ -1815,7 +1813,7 @@ export class GLViewer {
      * @return {boolean}
      */
     private atomIsSelected(atom: AtomSpec, sel: AtomSelectionSpec) {
-        if (sel === undefined)
+        if (typeof sel === "undefined")
             sel = {};
 
         var ms = this.getModelList(sel);
@@ -1846,7 +1844,7 @@ export class GLViewer {
     *
     */
     public getUniqueValues(attribute: string, sel?: AtomSelectionSpec) {
-        if (sel === undefined)
+        if (typeof sel === "undefined")
             sel = {};
         var atoms = this.getAtomsFromSel(sel);
         var values = {};
@@ -3759,8 +3757,7 @@ export class GLViewer {
 
         for (let i = 0; i < atomlist.length; i++) {
             var atom = atomlist[i];
-            if (atom === undefined)
-                continue;
+            if (atom === undefined) continue;
 
             if (atom.x < extent[0][0] || atom.x > extent[1][0])
                 continue;
@@ -4321,7 +4318,7 @@ export class GLViewer {
 
                         //    console.log("async mesh generation " + (+new Date() - time) + "ms");
                         cnt++;
-                        if (cnt === extents.length) {
+                        if (cnt == extents.length) {
                             surfobj.done = true;
                             releaseMemory();
                             resolve(surfid); //caller of helper will resolve callback if present

--- a/src/GLViewer.ts
+++ b/src/GLViewer.ts
@@ -567,13 +567,13 @@ export class GLViewer {
         this.nomouse = this.config.nomouse;
         this.bgColor = 0;
         this.config.backgroundColor = this.config.backgroundColor || "#ffffff";
-        if (typeof (this.config.backgroundColor) !== 'undefined') {
+        if (this.config?.backgroundColor !== undefined) {
             this.bgColor = CC.color(this.config.backgroundColor).getHex();
         }
         this.config.backgroundAlpha = this.config.backgroundAlpha == undefined ? 1.0 : this.config.backgroundAlpha;
 
         this.camerax = 0;
-        if (typeof (this.config.camerax) !== 'undefined') {
+        if (this.config?.camerax !== undefined) {
             this.camerax = parseFloat(this.config.camerax);
         }
         this._viewer = this;
@@ -623,7 +623,7 @@ export class GLViewer {
 
         window.addEventListener("resize", this.resize.bind(this));
 
-        if (typeof (window.ResizeObserver) !== "undefined") {
+        if (window.ResizeObserver !== undefined) {
             this.divwatcher = new window.ResizeObserver(this.resize.bind(this));
             this.divwatcher.observe(this.container);
         }
@@ -825,7 +825,7 @@ export class GLViewer {
         });
     */
     public setZoomLimits(lower, upper) {
-        if (typeof (lower) !== 'undefined') this.config.lowerZoomLimit = lower;
+        if (lower !== undefined) this.config.lowerZoomLimit = lower;
         if (upper) this.config.upperZoomLimit = upper;
         this.rotationGroup.position.z = this.adjustZoomToLimits(this.rotationGroup.position.z);
         this.show();
@@ -1204,7 +1204,7 @@ export class GLViewer {
      *
      */
     public setBackgroundColor(hex: ColorSpec, a: number) {
-        if (typeof (a) === "undefined") {
+        if (a === undefined) {
             a = 1.0;
         }
         else if (a < 0 || a > 1.0) {
@@ -1387,7 +1387,7 @@ export class GLViewer {
      */
     public spin(axis, speed: number = 1) {
         clearInterval(this.spinInterval);
-        if (typeof axis === 'undefined')
+        if (axis === undefined)
             axis = 'y';
         if (typeof axis === "boolean") {
             if (!axis)
@@ -1471,7 +1471,7 @@ export class GLViewer {
             if (mpos) {
                 delta.mpos = mpos.clone().sub(curr.mpos).multiplyScalar(frac);
             }
-            if (typeof (rz) !== 'undefined' && rz != null) {
+            if (rz !== undefined && rz != null) {
                 delta.rz = frac * (rz - curr.rz);
             }
             if (rot) {
@@ -1553,7 +1553,7 @@ export class GLViewer {
             axis = { vx: 0, vy: 0, vz: 1 };
         }
 
-        if (typeof (axis.vx) !== 'undefined') {
+        if (axis.vx !== undefined) {
             var vaxis = new Vector3(axis.vx, axis.vy, axis.vz);
             vaxis.applyQuaternion(this.rotationGroup.quaternion);
             axis = { x: vaxis.x, y: vaxis.y, z: vaxis.z };
@@ -1630,7 +1630,7 @@ export class GLViewer {
         this.rotationGroup.quaternion.y = arg[5];
         this.rotationGroup.quaternion.z = arg[6];
         this.rotationGroup.quaternion.w = arg[7];
-        if (typeof (arg[8]) !== "undefined") {
+        if (arg[8] !== undefined) {
             this.rotationGroup.position.x = arg[8];
             this.rotationGroup.position.y = arg[9];
         }
@@ -1666,8 +1666,8 @@ export class GLViewer {
 
         for (i = 0; i < this.shapes.length; i++) {
             if (this.shapes[i]) { //exists
-                if ((typeof (this.shapes[i].frame) === 'undefined' || this.viewer_frame < 0 ||
-                    this.shapes[i].frame < 0 || this.shapes[i].frame == this.viewer_frame)) {
+                if (this.shapes[i].frame === undefined || this.viewer_frame < 0 ||
+                    this.shapes[i].frame < 0 || this.shapes[i].frame == this.viewer_frame) {
                     this.shapes[i].globj(this.modelGroup, exts);
                 } else { //should not be displayed in current frame
                     this.shapes[i].removegl(this.modelGroup);
@@ -1676,7 +1676,7 @@ export class GLViewer {
         }
 
         for (i = 0; i < this.labels.length; i++) {
-            if (this.labels[i] && typeof (this.labels[i].frame) !== 'undefined' && this.labels[i].frame >= 0) { //exists and has frame specifier
+            if (this.labels[i] && this.labels[i].frame !== undefined && this.labels[i].frame >= 0) { //exists and has frame specifier
                 this.modelGroup.remove(this.labels[i].sprite);
                 if (this.viewer_frame < 0 || this.labels[i].frame == this.viewer_frame) {
                     this.modelGroup.add(this.labels[i].sprite);
@@ -1761,7 +1761,7 @@ export class GLViewer {
      */
     private getModelList(sel: any): GLModel[] {
         let ms: GLModel[] = [];
-        if (typeof sel === 'undefined' || typeof sel.model === "undefined") {
+        if (sel === undefined ||  sel.model === undefined) {
             for (let i = 0; i < this.models.length; i++) {
                 if (this.models[i])
                     ms.push(this.models[i]);
@@ -1794,7 +1794,7 @@ export class GLViewer {
      */
     private getAtomsFromSel(sel: AtomSelectionSpec): AtomSpec[] {
         var atoms = [];
-        if (typeof (sel) === "undefined")
+        if (sel === undefined)
             sel = {};
 
         var ms = this.getModelList(sel);
@@ -1815,7 +1815,7 @@ export class GLViewer {
      * @return {boolean}
      */
     private atomIsSelected(atom: AtomSpec, sel: AtomSelectionSpec) {
-        if (typeof (sel) === "undefined")
+        if (sel === undefined)
             sel = {};
 
         var ms = this.getModelList(sel);
@@ -1846,7 +1846,7 @@ export class GLViewer {
     *
     */
     public getUniqueValues(attribute: string, sel?: AtomSelectionSpec) {
-        if (typeof (sel) === "undefined")
+        if (sel === undefined)
             sel = {};
         var atoms = this.getAtomsFromSel(sel);
         var values = {};
@@ -2517,7 +2517,7 @@ export class GLViewer {
         delete this.shapes[shape.shapePosition];
         // clear off back of model array
         while (this.shapes.length > 0
-            && typeof (this.shapes[this.shapes.length - 1]) === "undefined")
+            && this.shapes[this.shapes.length - 1] === undefined)
             this.shapes.pop();
         return this;
     };
@@ -3395,7 +3395,7 @@ export class GLViewer {
         if (options && !options.defaultcolors) {
             options.defaultcolors = this.defaultcolors;
             options.cartoonQuality = options.cartoonQuality || this.config.cartoonQuality;
-        } else if (typeof (options) === 'undefined') {
+        } else if (options === undefined) {
             options = { defaultcolors: this.defaultcolors, cartoonQuality: this.config.cartoonQuality };
         }
         var m = new GLModel(this.models.length, options);
@@ -3504,7 +3504,7 @@ export class GLViewer {
         delete this.models[model.getID()];
         // clear off back of model array
         while (this.models.length > 0
-            && typeof (this.models[this.models.length - 1]) === "undefined")
+            && this.models[this.models.length - 1] === undefined)
             this.models.pop();
         return this;
     };
@@ -3610,7 +3610,7 @@ export class GLViewer {
     public setStyle(sel:AtomSelectionSpec, style:AtomStyleSpec);
     public setStyle(sel:AtomStyleSpec);
     public setStyle(sel:unknown, style?:unknown) {
-        if (typeof (style) === 'undefined') {
+        if (style === undefined) {
             //if a single argument is provided, assume it is a style and select all
             style = sel as AtomStyleSpec;
             sel = {};
@@ -3638,7 +3638,7 @@ export class GLViewer {
     public addStyle(sel:AtomSelectionSpec, style:AtomStyleSpec);
     public addStyle(sel:AtomStyleSpec);
     public addStyle(sel:unknown, style?:unknown) {
-        if (typeof (style) === 'undefined') {
+        if (style === undefined) {
             //if a single argument is provided, assume it is a style and select all
             style = sel;
             sel = {};
@@ -3759,7 +3759,7 @@ export class GLViewer {
 
         for (let i = 0; i < atomlist.length; i++) {
             var atom = atomlist[i];
-            if (typeof (atom) === "undefined")
+            if (atom === undefined)
                 continue;
 
             if (atom.x < extent[0][0] || atom.x > extent[1][0])
@@ -3902,7 +3902,7 @@ export class GLViewer {
         for (let i = 0, il = atoms.length; i < il; i++) {
             var atom = atoms[i];
             if (atom) {
-                if (typeof (atom.surfaceColor) !== "undefined") {
+                if (atom.surfaceColor !== undefined) {
                     colors[i] = atom.surfaceColor;
                 } else if (atom.color) // map from atom
                     colors[i] = CC.color(atom.color);

--- a/src/Gradient.ts
+++ b/src/Gradient.ts
@@ -64,7 +64,7 @@ export class RWB extends GradientType {
     this.mid = mid;
     this.min = min as number;
     this.max = max as number;
-    if (typeof max == "undefined" && Array.isArray(min) && min.length >= 2) {
+    if (typeof max === "undefined" && Array.isArray(min) && min.length >= 2) {
       //we were passed a single range
       this.max = min[1];
       this.min = min[0];
@@ -76,7 +76,7 @@ export class RWB extends GradientType {
 
   //return range used for color mapping, null if none set
   range() {
-    if (typeof this.min != "undefined" && typeof this.max != "undefined") {
+    if (typeof this.min !== "undefined" && typeof this.max !== "undefined") {
       return [this.min, this.max] as [number, number];
     }
     return null;
@@ -102,8 +102,8 @@ export class RWB extends GradientType {
     val = norm.val;
 
     var middle = (hi + lo) / 2;
-    if (range && typeof range[2] != "undefined") middle = range[2];
-    else if (typeof this.mid != "undefined")
+    if (range && typeof range[2] !== "undefined") middle = range[2];
+    else if (typeof this.mid !== "undefined")
       middle = this.mid; //allow user to specify midpoint
     else middle = (lo + hi) / 2;
     var scale: number, color: number;
@@ -140,7 +140,7 @@ export class ROYGB extends GradientType {
     this.mult = 1.0;
     this.min = min;
     this.max = max;
-    if (typeof max == "undefined" && Array.isArray(min) && min.length >= 2) {
+    if (typeof max === "undefined" && Array.isArray(min) && min.length >= 2) {
       //we were passed a single range
       this.max = min[1];
       this.min = min[0];
@@ -161,7 +161,7 @@ export class ROYGB extends GradientType {
       hi = this.max!;
     }
 
-    if (typeof val == "undefined") return 0xffffff;
+    if (typeof val === "undefined") return 0xffffff;
 
     var norm = normalizeValue(lo, hi, val);
     lo = norm.lo;
@@ -198,7 +198,7 @@ export class ROYGB extends GradientType {
 
   //return range used for color mapping, null if none set
   range() {
-    if (typeof this.min != "undefined" && typeof this.max != "undefined") {
+    if (typeof this.min !== "undefined" && typeof this.max !== "undefined") {
       return [this.min, this.max] as [number, number];
     }
     return null;
@@ -233,7 +233,7 @@ export class Sinebow extends GradientType {
     this.mult = 1.0;
     this.min = min;
     this.max = max;
-    if (typeof max == "undefined" && Array.isArray(min) && min.length >= 2) {
+    if (typeof max === "undefined" && Array.isArray(min) && min.length >= 2) {
       //we were passed a single range
       this.max = min[1];
       this.min = min[0];
@@ -258,7 +258,7 @@ export class Sinebow extends GradientType {
       hi = this.max;
     }
 
-    if (typeof val == "undefined") return 0xffffff;
+    if (typeof val === "undefined") return 0xffffff;
     var norm = Gradient.normalizeValue(lo, hi, val);
     lo = norm.lo;
     hi = norm.hi;
@@ -280,7 +280,7 @@ export class Sinebow extends GradientType {
 
   //return range used for color mapping, null if none set
   range() {
-    if (typeof this.min != "undefined" && typeof this.max != "undefined") {
+    if (typeof this.min !== "undefined" && typeof this.max !== "undefined") {
       return [this.min, this.max] as [number, number];
     }
     return null;
@@ -340,7 +340,7 @@ export class CustomLinear extends GradientType {
 
   //return range used for color mapping, null if none set
   range() {
-    if (typeof this.min != "undefined" && typeof this.max != "undefined") {
+    if (typeof this.min !== "undefined" && typeof this.max !== "undefined") {
       return [this.min, this.max] as [number, number];
     }
     return null;

--- a/src/Gradient.ts
+++ b/src/Gradient.ts
@@ -64,7 +64,7 @@ export class RWB extends GradientType {
     this.mid = mid;
     this.min = min as number;
     this.max = max as number;
-    if (typeof max === "undefined" && Array.isArray(min) && min.length >= 2) {
+    if (max === undefined && Array.isArray(min) && min.length >= 2) {
       //we were passed a single range
       this.max = min[1];
       this.min = min[0];
@@ -76,7 +76,7 @@ export class RWB extends GradientType {
 
   //return range used for color mapping, null if none set
   range() {
-    if (typeof this.min !== "undefined" && typeof this.max !== "undefined") {
+    if (this.min !== undefined && this.max !== undefined) {
       return [this.min, this.max] as [number, number];
     }
     return null;
@@ -102,8 +102,8 @@ export class RWB extends GradientType {
     val = norm.val;
 
     var middle = (hi + lo) / 2;
-    if (range && typeof range[2] !== "undefined") middle = range[2];
-    else if (typeof this.mid !== "undefined")
+    if (range && range[2] !== undefined) middle = range[2];
+    else if (this.mid !== undefined)
       middle = this.mid; //allow user to specify midpoint
     else middle = (lo + hi) / 2;
     var scale: number, color: number;
@@ -140,7 +140,7 @@ export class ROYGB extends GradientType {
     this.mult = 1.0;
     this.min = min;
     this.max = max;
-    if (typeof max === "undefined" && Array.isArray(min) && min.length >= 2) {
+    if (max === undefined && Array.isArray(min) && min.length >= 2) {
       //we were passed a single range
       this.max = min[1];
       this.min = min[0];
@@ -161,7 +161,7 @@ export class ROYGB extends GradientType {
       hi = this.max!;
     }
 
-    if (typeof val === "undefined") return 0xffffff;
+    if (val === undefined) return 0xffffff;
 
     var norm = normalizeValue(lo, hi, val);
     lo = norm.lo;
@@ -198,7 +198,7 @@ export class ROYGB extends GradientType {
 
   //return range used for color mapping, null if none set
   range() {
-    if (typeof this.min !== "undefined" && typeof this.max !== "undefined") {
+    if (this.min !== undefined && this.max !== undefined) {
       return [this.min, this.max] as [number, number];
     }
     return null;
@@ -233,7 +233,7 @@ export class Sinebow extends GradientType {
     this.mult = 1.0;
     this.min = min;
     this.max = max;
-    if (typeof max === "undefined" && Array.isArray(min) && min.length >= 2) {
+    if (max === undefined && Array.isArray(min) && min.length >= 2) {
       //we were passed a single range
       this.max = min[1];
       this.min = min[0];
@@ -258,7 +258,7 @@ export class Sinebow extends GradientType {
       hi = this.max;
     }
 
-    if (typeof val === "undefined") return 0xffffff;
+    if (val === undefined) return 0xffffff;
     var norm = Gradient.normalizeValue(lo, hi, val);
     lo = norm.lo;
     hi = norm.hi;
@@ -280,7 +280,7 @@ export class Sinebow extends GradientType {
 
   //return range used for color mapping, null if none set
   range() {
-    if (typeof this.min !== "undefined" && typeof this.max !== "undefined") {
+    if (this.min !== undefined && this.max !== undefined) {
       return [this.min, this.max] as [number, number];
     }
     return null;
@@ -340,7 +340,7 @@ export class CustomLinear extends GradientType {
 
   //return range used for color mapping, null if none set
   range() {
-    if (typeof this.min !== "undefined" && typeof this.max !== "undefined") {
+    if (this.min !== undefined && this.max !== undefined) {
       return [this.min, this.max] as [number, number];
     }
     return null;

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -33,18 +33,18 @@ function roundRect(ctx: CanvasRenderingContext2D, x: any, y: any, w: number, h: 
 //do all the checks to figure out what color is desired
 function getColor(style: any, stylealpha?: any, init?: any) {
   var ret = init;
-  if (typeof style != "undefined") {
+  if (typeof style !== "undefined") {
     //convet regular colors
     if (style instanceof Color) ret = style.scaled();
     else {
       //hex or name
       ret = CC.color(style);
-      if (typeof ret.scaled != "undefined") {
+      if (typeof ret.scaled !== "undefined") {
         ret = ret.scaled(); //not already scaled to 255
       }
     }
   }
-  if (typeof stylealpha != "undefined") {
+  if (typeof stylealpha !== "undefined") {
     ret.a = parseFloat(stylealpha);
   }
   return ret;
@@ -125,12 +125,12 @@ export class Label {
   setContext() {
     var style = this.stylespec;
     var useScreen =
-      typeof style.useScreen == "undefined" ? false : style.useScreen;
+      typeof style.useScreen === "undefined" ? false : style.useScreen;
 
     var showBackground = style.showBackground;
     if (showBackground === "0" || showBackground === "false")
       showBackground = false;
-    if (typeof showBackground == "undefined") showBackground = true; //default
+    if (typeof showBackground === "undefined") showBackground = true; //default
     var font = style.font ? style.font : "sans-serif";
 
     var fontSize = parseInt(style.fontSize) ? parseInt(style.fontSize) : 18;
@@ -178,7 +178,7 @@ export class Label {
 
     var spriteAlignment = style.alignment || SpriteAlignment.topLeft;
     if (
-      typeof spriteAlignment == "string" &&
+      typeof spriteAlignment === "string" &&
       spriteAlignment in SpriteAlignment
     ) {
       spriteAlignment = (SpriteAlignment as any)[spriteAlignment] ;

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -33,18 +33,18 @@ function roundRect(ctx: CanvasRenderingContext2D, x: any, y: any, w: number, h: 
 //do all the checks to figure out what color is desired
 function getColor(style: any, stylealpha?: any, init?: any) {
   var ret = init;
-  if (typeof style !== "undefined") {
+  if (style !== undefined) {
     //convet regular colors
     if (style instanceof Color) ret = style.scaled();
     else {
       //hex or name
       ret = CC.color(style);
-      if (typeof ret.scaled !== "undefined") {
+      if (ret.scaled !== undefined) {
         ret = ret.scaled(); //not already scaled to 255
       }
     }
   }
-  if (typeof stylealpha !== "undefined") {
+  if (stylealpha !== undefined) {
     ret.a = parseFloat(stylealpha);
   }
   return ret;
@@ -125,12 +125,12 @@ export class Label {
   setContext() {
     var style = this.stylespec;
     var useScreen =
-      typeof style.useScreen === "undefined" ? false : style.useScreen;
+      style?.useScreen === undefined ? false : style.useScreen;
 
     var showBackground = style.showBackground;
     if (showBackground === "0" || showBackground === "false")
       showBackground = false;
-    if (typeof showBackground === "undefined") showBackground = true; //default
+    if (showBackground === undefined) showBackground = true; //default
     var font = style.font ? style.font : "sans-serif";
 
     var fontSize = parseInt(style.fontSize) ? parseInt(style.fontSize) : 18;

--- a/src/ProteinSurface4.ts
+++ b/src/ProteinSurface4.ts
@@ -788,7 +788,7 @@ export class ProteinSurface {
         };
     
     private getVDWIndex(atom:any) {
-        if(!atom.elem || typeof(this.vdwRadii[atom.elem]) == "undefined") {
+        if(!atom.elem || typeof(this.vdwRadii[atom.elem]) === "undefined") {
             return "X";
         }
         return atom.elem;

--- a/src/ProteinSurface4.ts
+++ b/src/ProteinSurface4.ts
@@ -788,7 +788,7 @@ export class ProteinSurface {
         };
     
     private getVDWIndex(atom:any) {
-        if(!atom.elem || typeof(this.vdwRadii[atom.elem]) === "undefined") {
+        if(!atom.elem || this.vdwRadii[atom.elem] === undefined) {
             return "X";
         }
         return atom.elem;

--- a/src/VolumeData.ts
+++ b/src/VolumeData.ts
@@ -53,7 +53,7 @@ export class VolumeData {
             format = format.replace(/\.gz$/, '');
             try {
                 if ((this as any)[format] && this.isbinary.has(format)) {
-                    if (typeof (str) == "string") {
+                    if (typeof (str) === "string") {
                         //assume base64 encoded
                         str = base64ToArray(str);
                     }
@@ -68,7 +68,7 @@ export class VolumeData {
         }
 
         if ((this as any)[format]) {
-            if (this.isbinary.has(format) && typeof (str) == "string") {
+            if (this.isbinary.has(format) && typeof (str) === "string") {
                 str = base64ToArray(str);
             }
             (this as any)[format](str);
@@ -179,7 +179,7 @@ export class VolumeData {
         var atomicData = VASP(str)[0];
         var natoms = atomicData.length;
 
-        if (natoms == 0) {
+        if (natoms === 0) {
             console.log("No good formating of CHG or CHGCAR file, not atomic information provided in the file.");
             this.data = [];
             return;
@@ -232,8 +232,8 @@ export class VolumeData {
         yVec = yVec.multiplyScalar(1 / (l_units * nY));
         zVec = zVec.multiplyScalar(1 / (l_units * nZ));
 
-        if (xVec.y != 0 || xVec.z != 0 || yVec.x != 0 || yVec.z != 0 || zVec.x != 0
-            || zVec.y != 0) {
+        if (xVec.y !== 0 || xVec.z !== 0 || yVec.x !== 0 || yVec.z !== 0 || zVec.x !== 0
+            || zVec.y !== 0) {
             //need a transformation matrix
             this.matrix = new Matrix4(xVec.x, yVec.x, zVec.x, 0, xVec.y, yVec.y, zVec.y, 0, xVec.z, yVec.z, zVec.z, 0, 0, 0, 0, 1);
             //include translation in matrix
@@ -290,7 +290,7 @@ export class VolumeData {
             }
             else if ((m = redelta.exec(line))) {
                 var xunit = parseFloat(m[1]);
-                if (parseFloat(m[2]) != 0 || parseFloat(m[3]) != 0) {
+                if (parseFloat(m[2]) !== 0 || parseFloat(m[3]) !== 0) {
                     console.log("Non-orthogonal delta matrix not currently supported in dx format");
                 }
                 i += 1;
@@ -302,7 +302,7 @@ export class VolumeData {
                 }
 
                 var yunit = parseFloat(m[2]);
-                if (parseFloat(m[1]) != 0 || parseFloat(m[3]) != 0) {
+                if (parseFloat(m[1]) !== 0 || parseFloat(m[3]) !== 0) {
                     console.log("Non-orthogonal delta matrix not currently supported in dx format");
                 }
 
@@ -315,7 +315,7 @@ export class VolumeData {
                 }
 
                 var zunit = parseFloat(m[3]);
-                if (parseFloat(m[1]) != 0 || parseFloat(m[2]) != 0) {
+                if (parseFloat(m[1]) !== 0 || parseFloat(m[2]) !== 0) {
                     console.log("Non-orthogonal delta matrix not currently supported in dx format");
                 }
                 this.unit = new Vector3(xunit, yunit, zunit);

--- a/src/VolumetricRender.ts
+++ b/src/VolumetricRender.ts
@@ -76,7 +76,7 @@ export class GLVolumetricRender {
         transferfn.forEach(function (a: { value: any; }) { a.value = parseFloat(a.value); });
         transferfn.sort(function (a: { value: number; }, b: { value: number; }) { return a.value - b.value; });
         this.min = transferfn[0].value;
-        if (transferfn.length == 0) transferfn.push(transferfn[0]); //need at least two
+        if (transferfn.length === 0) transferfn.push(transferfn[0]); //need at least two
         this.max = transferfn[transferfn.length - 1].value;
 
         // create and fill an array of interpolated values per 2 colors
@@ -88,7 +88,7 @@ export class GLVolumetricRender {
             alpha2 = transferfn[i + 1].opacity;
             pos1 = Math.floor((transferfn[i].value - this.min) * TRANSFER_BUFFER_SIZE / (this.max - this.min));
             pos2 = Math.floor((transferfn[i + 1].value - this.min) * TRANSFER_BUFFER_SIZE / (this.max - this.min));
-            if (pos1 == pos2)
+            if (pos1 === pos2)
                 continue;
             R = GLVolumetricRender.interpolateArray([color1.r * 255, color2.r * 255], pos2 - pos1);
             G = GLVolumetricRender.interpolateArray([color1.g * 255, color2.g * 255], pos2 - pos1);

--- a/src/autoload.ts
+++ b/src/autoload.ts
@@ -31,7 +31,7 @@ export function autoload(viewer?: any, callback?: (arg0: any) => void) {
             var datatypes = [];
             var uri = '';
 
-            if (viewerdiv.style.position == 'static') {
+            if (viewerdiv.style.position === 'static') {
                 //slight hack - canvas needs this element to be positioned
                 viewerdiv.style.position = 'relative';
             }
@@ -58,7 +58,7 @@ export function autoload(viewer?: any, callback?: (arg0: any) => void) {
                 datatypes.push(type);
 
                 var molName = uri.substring(uri.lastIndexOf('/') + 1, uri.lastIndexOf('.'));
-                if (molName == '/')
+                if (molName === '/')
                     molName = uri.substring(uri.lastIndexOf('/') + 1);
 
                 viewerdiv.dataset[datatypes[datatypes.length - 1]] = molName;
@@ -134,10 +134,10 @@ export function autoload(viewer?: any, callback?: (arg0: any) => void) {
                     styleobj = specStringToObject(d[dataname]);
                     labels.push([newsel, styleobj]);
                 }
-                if (dataname == "zoomto") {
+                if (dataname === "zoomto") {
                     zoomto = specStringToObject(d[dataname]);
                 }
-                if (dataname == "spin") {
+                if (dataname === "spin") {
                     spin = specStringToObject(d[dataname]);
                 }
             }
@@ -210,7 +210,7 @@ export function autoload(viewer?: any, callback?: (arg0: any) => void) {
                 viewerdiv.textContent = "WebGL appears to be disabled.";
             }
 
-            if (datauri.length != 0) {
+            if (datauri.length !== 0) {
                 //load multiple data elements in serial
                 let i = 0;
                 var process = function (moldata: any) {
@@ -233,7 +233,7 @@ export function autoload(viewer?: any, callback?: (arg0: any) => void) {
                             //evaluate javascript in the string, if it resolves to a function,
                             //call it with the viewer
                             /*jshint -W061 */ var runres = eval(viewerdiv.dataset.callback);
-                            if (typeof (runres) == 'function') {
+                            if (typeof (runres) === 'function') {
                                 runres(glviewer);
                             }
                         }
@@ -259,7 +259,7 @@ export function autoload(viewer?: any, callback?: (arg0: any) => void) {
                     //evaluate javascript in the string, if it resolves to a function,
                     //call it with the viewer
                     /*jshint -W061 */ var runres = eval(viewerdiv.dataset.callback);
-                    if (typeof (runres) == 'function') {
+                    if (typeof (runres) === 'function') {
                         runres(glviewer);
                     }
                 }

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -136,11 +136,11 @@ export class CC {
       if (!isNaN(parseInt(hexs))) return parseInt(hexs);
       hexs = hexs.trim();
 
-      if (hexs.length == 4 && hexs[0] == "#") {
+      if (hexs.length === 4 && hexs[0] === "#") {
         hexs = "#" + hexs[1] + hexs[1] + hexs[2] + hexs[2] + hexs[3] + hexs[3]; //expand to full hex number
       }
 
-      if (hexs.length == 7 && hexs[0] == "#") {
+      if (hexs.length === 7 && hexs[0] === "#") {
         return parseInt(hexs.substring(1), 16);
       }
 

--- a/src/glcartoon.ts
+++ b/src/glcartoon.ts
@@ -240,7 +240,7 @@ function drawShapeStrip(geo: Geometry, points, colors, div, thickness, opacity, 
         let gnum = geo.groups;
         let replicating = false;
         geoGroup = geo.updateGeoGroup(2 * num); // ensure vertex capacity
-        if (gnum != geo.groups && i > 0) {
+        if (gnum !== geo.groups && i > 0) {
             //we created a new geo - need to replicate vertices at edge 
             //(but not faces)
             i = i - 1;
@@ -727,9 +727,9 @@ function inConnectedResidues(a, b) {
             var dy = a.y - b.y;
             var dz = a.z - b.z;
             var dist = dx * dx + dy * dy + dz * dz;
-            if (a.atom == "CA" && b.atom == "CA" && dist < 16.0) //protein residues not connected
+            if (a.atom === "CA" && b.atom === "CA" && dist < 16.0) //protein residues not connected
                 return true; // calpha dist
-            else if ((a.atom == "P" || b.atom == "P") && dist < 64.0) //dna
+            else if ((a.atom === "P" || b.atom === "P") && dist < 64.0) //dna
                 return true;
         }
     }
@@ -951,8 +951,8 @@ export function drawCartoon(group, atomList, gradientrange, quality = 10) {
             }
 
             // first and last residues in a helix are used to draw tube
-            if (connected && (curr.ss === "h" || curr.ss == "tube start") && curr.style.cartoon.tubes) {
-                if (!inHelix && curr.ss != "tube start" && next.style.cartoon.tubes) {
+            if (connected && (curr.ss === "h" || curr.ss === "tube start") && curr.style.cartoon.tubes) {
+                if (!inHelix && curr.ss !== "tube start" && next.style.cartoon.tubes) {
                     next.ss = "tube start";
                     inHelix = true;
                 }
@@ -1088,7 +1088,7 @@ export function drawCartoon(group, atomList, gradientrange, quality = 10) {
         } else // draw default-style cartoons based on secondary structure
         {
             // draw backbone through these atoms
-            if (isAlphaCarbon(next) || inNucleicAcid && (next.atom === "P" || next.atom.indexOf('O5') == 0)) {
+            if (isAlphaCarbon(next) || inNucleicAcid && (next.atom === "P" || next.atom.indexOf('O5') === 0)) {
                 if (drawingTube) {
                     if (next.ss === "tube end") {
                         drawingTube = false;
@@ -1155,7 +1155,7 @@ export function drawCartoon(group, atomList, gradientrange, quality = 10) {
                 }
 
                 // reached next residue (potentially the first residue)
-                if (curr === undefined || curr.rescode != next.rescode || curr.resi != next.resi) {
+                if (curr === undefined || curr.rescode !== next.rescode || curr.resi !== next.resi) {
                     if (baseEndPt && curr != undefined) // draw last NA residue's base
                     {
                         // start the cylinder at the midpoint between
@@ -1204,8 +1204,8 @@ export function drawCartoon(group, atomList, gradientrange, quality = 10) {
             else if (curr != undefined && (isAlphaCarbon(curr) && next.atom === "O" ||
                 inNucleicAcid && curr.atom === "P" &&
                 (next.atom === "OP2" || next.atom === "O2P") ||
-                inNucleicAcid && curr.atom.indexOf("O5") == 0 &&
-                next.atom.indexOf("C5") == 0)) {
+                inNucleicAcid && curr.atom.indexOf("O5") === 0 &&
+                next.atom.indexOf("C5") === 0)) {
                 orientPt = new Vector3(next.x, next.y, next.z);
                 orientPt.resi = next.resi;
                 if (next.atom === "OP2" || next.atom === "O2P") // for NA 3'
@@ -1216,7 +1216,7 @@ export function drawCartoon(group, atomList, gradientrange, quality = 10) {
 
             // NA 3' terminus is an edge case, need a vector for most recent
             // O3'
-            else if (inNucleicAcid && next.atom.indexOf("O3") == 0) {
+            else if (inNucleicAcid && next.atom.indexOf("O3") === 0) {
                 terminalPt = new Vector3(next.x, next.y, next.z);
             }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -64,7 +64,7 @@ export function makeFunction(callback:Func) {
         /* jshint ignore:end */
     }
     // report to console if callback is not a valid function
-    if (callback && typeof callback != "function") {
+    if (callback && typeof callback !== "function") {
         return null;
     }
     return callback;
@@ -220,9 +220,9 @@ export function base64ToArray(base64) {
 export function getAtomProperty(atom, prop) {
     var val = null;
     if (atom.properties &&
-        typeof (atom.properties[prop]) != "undefined") {
+        typeof (atom.properties[prop]) !== "undefined") {
         val = atom.properties[prop];
-    } else if (typeof (atom[prop]) != 'undefined') {
+    } else if (typeof (atom[prop]) !== 'undefined') {
         val = atom[prop];
     }
     return val;
@@ -283,7 +283,7 @@ export function specStringToObject(str) {
     var massage = function (val) {
         if (isNumeric(val)) {
             //hexadecimal does not parse as float
-            if (Math.floor(parseFloat(val)) == parseInt(val)) {
+            if (Math.floor(parseFloat(val)) === parseInt(val)) {
                 return parseFloat(val);
             }
             else if (val.indexOf('.') >= 0) {
@@ -369,7 +369,7 @@ export function get(uri, callback?) {
  */
 export function getbin(uri, callback?, request?, postdata?) {
     var promise;
-    if (request == "POST") {
+    if (request === "POST") {
         promise = fetch(uri, { method: 'POST', body: postdata })
             .then((response) => checkStatus(response))
             .then((response) => response.arrayBuffer());
@@ -411,7 +411,7 @@ export function download(query, viewer, options, callback?) {
 
     if (query.indexOf(':') < 0) {
         //no type specifier, guess
-        if (query.length == 4) {
+        if (query.length === 4) {
             query = 'pdb:' + query;
         } else if (!isNaN(query)) {
             query = 'cid:' + query;
@@ -453,7 +453,7 @@ export function download(query, viewer, options, callback?) {
                 alert("Wrong PDB ID");
                 return;
             }
-            if (type == 'mmtf') {
+            if (type === 'mmtf') {
                 mmtfUri = options && options.mmtfUri ? options.mmtfUri : 'https://mmtf.rcsb.org/v1.0/full/';
                 uri = mmtfUri + query.toUpperCase();
             }
@@ -462,7 +462,7 @@ export function download(query, viewer, options, callback?) {
                 uri = pdbUri + query + "." + type;
             }
 
-        } else if (query.substring(0, 4) == 'cid:') {
+        } else if (query.substring(0, 4) === 'cid:') {
             type = "sdf";
             query = query.substring(4);
             if (!query.match(/^[0-9]+$/)) {
@@ -470,7 +470,7 @@ export function download(query, viewer, options, callback?) {
             }
             uri = "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/" + query +
                 "/SDF?record_type=3d";
-        } else if (query.substring(0, 4) == 'url:') {
+        } else if (query.substring(0, 4) === 'url:') {
             uri = query.substring(4);
             type = uri;
         }
@@ -481,7 +481,7 @@ export function download(query, viewer, options, callback?) {
             viewer.render();
         };
         promise = new Promise(function (resolve) {
-            if (type == 'mmtf') { //binary data
+            if (type === 'mmtf') { //binary data
                 getbin(uri)
                     .then(function (ret) {
                         handler(ret);
@@ -531,14 +531,14 @@ export function download(query, viewer, options, callback?) {
  */
 export function getColorFromStyle(atom, style): Color {
     let scheme = style.colorscheme;
-    if (typeof builtinColorSchemes[scheme] != "undefined") {
+    if (typeof builtinColorSchemes[scheme] !== "undefined") {
         scheme = builtinColorSchemes[scheme];
-    } else if (typeof scheme == "string" && scheme.endsWith("Carbon")) {
+    } else if (typeof scheme === "string" && scheme.endsWith("Carbon")) {
         //any color you want of carbon
         let ccolor = scheme
             .substring(0, scheme.lastIndexOf("Carbon"))
             .toLowerCase();
-        if (typeof htmlColors[ccolor] != "undefined") {
+        if (typeof htmlColors[ccolor] !== "undefined") {
             let newscheme = { ...elementColors.defaultColors };
             newscheme.C = htmlColors[ccolor];
             builtinColorSchemes[scheme] = { prop: "elem", map: newscheme };
@@ -547,27 +547,27 @@ export function getColorFromStyle(atom, style): Color {
     }
 
     let color = atom.color;
-    if (typeof style.color != "undefined" && style.color != "spectrum")
+    if (typeof style.color !== "undefined" && style.color !== "spectrum")
         color = style.color;
-    if (typeof scheme != "undefined") {
+    if (typeof scheme !== "undefined") {
         let prop, val;
-        if (typeof elementColors[scheme] != "undefined") {
+        if (typeof elementColors[scheme] !== "undefined") {
             //name of builtin colorscheme
             scheme = elementColors[scheme];
-            if (typeof scheme[atom[scheme.prop]] != "undefined") {
+            if (typeof scheme[atom[scheme.prop]] !== "undefined") {
                 color = scheme.map[atom[scheme.prop]];
             }
-        } else if (typeof scheme[atom[scheme.prop]] != "undefined") {
+        } else if (typeof scheme[atom[scheme.prop]] !== "undefined") {
             //actual color scheme provided
             color = scheme.map[atom[scheme.prop]];
         } else if (
-            typeof scheme.prop != "undefined" &&
-            typeof scheme.gradient != "undefined"
+            typeof scheme.prop !== "undefined" &&
+            typeof scheme.gradient !== "undefined"
         ) {
             //apply a property mapping
             prop = scheme.prop;
             var grad = scheme.gradient; //redefining scheme
-            if (typeof builtinGradients[grad] != "undefined") {
+            if (typeof builtinGradients[grad] !== "undefined") {
                 grad = new builtinGradients[grad](
                     scheme.min,
                     scheme.max,
@@ -581,22 +581,22 @@ export function getColorFromStyle(atom, style): Color {
                 color = grad.valueToHex(val, range);
             }
         } else if (
-            typeof scheme.prop != "undefined" &&
-            typeof scheme.map != "undefined"
+            typeof scheme.prop !== "undefined" &&
+            typeof scheme.map !== "undefined"
         ) {
             //apply a discrete property mapping
             prop = scheme.prop;
             val = getAtomProperty(atom, prop);
-            if (typeof scheme.map[val] != "undefined") {
+            if (typeof scheme.map[val] !== "undefined") {
                 color = scheme.map[val];
             }
-        } else if (typeof style.colorscheme[atom.elem] != "undefined") {
+        } else if (typeof style.colorscheme[atom.elem] !== "undefined") {
             //actual color scheme provided
             color = style.colorscheme[atom.elem];
         } else {
             console.log("Could not interpret colorscheme " + scheme);
         }
-    } else if (typeof style.colorfunc != "undefined") {
+    } else if (typeof style.colorfunc !== "undefined") {
         //this is a user provided function for turning an atom into a color
         color = style.colorfunc(atom);
     }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -100,7 +100,7 @@ export function getExtent(atomlist, ignoreSymmetries?) {
         return [[0, 0, 0], [0, 0, 0], [0, 0, 0]];
     for (var i = 0; i < atomlist.length; i++) {
         var atom = atomlist[i];
-        if (typeof atom === 'undefined' || !isFinite(atom.x) ||
+        if (atom === undefined || !isFinite(atom.x) ||
             !isFinite(atom.y) || !isFinite(atom.z))
             continue;
         cnt++;
@@ -220,9 +220,9 @@ export function base64ToArray(base64) {
 export function getAtomProperty(atom, prop) {
     var val = null;
     if (atom.properties &&
-        typeof (atom.properties[prop]) !== "undefined") {
+        atom.properties[prop] !== undefined) {
         val = atom.properties[prop];
-    } else if (typeof (atom[prop]) !== 'undefined') {
+    } else if (atom?.[prop] !== undefined) {
         val = atom[prop];
     }
     return val;
@@ -266,7 +266,7 @@ export function specStringToObject(str) {
     if (typeof (str) === "object") {
         return str; //not string, assume was converted already
     }
-    else if (typeof (str) === "undefined" || str == null) {
+    else if (str === undefined || str == null) {
         return str;
     }
 
@@ -423,7 +423,7 @@ export function download(query, viewer, options, callback?) {
         pdbUri = options && options.pdbUri ? options.pdbUri : "https://mmtf.rcsb.org/v1.0/full/";
         query = query.substring(5).toUpperCase();
         uri = pdbUri + query;
-        if (options && typeof options.noComputeSecondaryStructure === 'undefined') {
+        if (options && options.noComputeSecondaryStructure === undefined) {
             //when fetch directly from pdb, trust structure annotations
             options.noComputeSecondaryStructure = true;
         }
@@ -444,7 +444,7 @@ export function download(query, viewer, options, callback?) {
                 type = options.format; //can override and require pdb
             }
 
-            if (options && typeof options.noComputeSecondaryStructure === 'undefined') {
+            if (options && options.noComputeSecondaryStructure === undefined) {
                 //when fetch directly from pdb, trust structure annotations
                 options.noComputeSecondaryStructure = true;
             }
@@ -531,14 +531,14 @@ export function download(query, viewer, options, callback?) {
  */
 export function getColorFromStyle(atom, style): Color {
     let scheme = style.colorscheme;
-    if (typeof builtinColorSchemes[scheme] !== "undefined") {
+    if (builtinColorSchemes[scheme] !== undefined) {
         scheme = builtinColorSchemes[scheme];
     } else if (typeof scheme === "string" && scheme.endsWith("Carbon")) {
         //any color you want of carbon
         let ccolor = scheme
             .substring(0, scheme.lastIndexOf("Carbon"))
             .toLowerCase();
-        if (typeof htmlColors[ccolor] !== "undefined") {
+        if (htmlColors[ccolor] !== undefined) {
             let newscheme = { ...elementColors.defaultColors };
             newscheme.C = htmlColors[ccolor];
             builtinColorSchemes[scheme] = { prop: "elem", map: newscheme };
@@ -547,27 +547,27 @@ export function getColorFromStyle(atom, style): Color {
     }
 
     let color = atom.color;
-    if (typeof style.color !== "undefined" && style.color !== "spectrum")
+    if (style.color !== undefined && style.color !== "spectrum")
         color = style.color;
-    if (typeof scheme !== "undefined") {
+    if (scheme !== undefined) {
         let prop, val;
-        if (typeof elementColors[scheme] !== "undefined") {
+        if (elementColors[scheme] !== undefined) {
             //name of builtin colorscheme
             scheme = elementColors[scheme];
-            if (typeof scheme[atom[scheme.prop]] !== "undefined") {
+            if (scheme[atom[scheme.prop]] !== undefined) {
                 color = scheme.map[atom[scheme.prop]];
             }
-        } else if (typeof scheme[atom[scheme.prop]] !== "undefined") {
+        } else if (scheme[atom[scheme.prop]] !== undefined) {
             //actual color scheme provided
             color = scheme.map[atom[scheme.prop]];
         } else if (
-            typeof scheme.prop !== "undefined" &&
-            typeof scheme.gradient !== "undefined"
+            scheme.prop !== undefined &&
+            scheme.gradient !== undefined
         ) {
             //apply a property mapping
             prop = scheme.prop;
             var grad = scheme.gradient; //redefining scheme
-            if (typeof builtinGradients[grad] !== "undefined") {
+            if (builtinGradients[grad] !== undefined) {
                 grad = new builtinGradients[grad](
                     scheme.min,
                     scheme.max,
@@ -581,22 +581,22 @@ export function getColorFromStyle(atom, style): Color {
                 color = grad.valueToHex(val, range);
             }
         } else if (
-            typeof scheme.prop !== "undefined" &&
-            typeof scheme.map !== "undefined"
+            scheme.prop !== undefined &&
+            scheme.map !== undefined
         ) {
             //apply a discrete property mapping
             prop = scheme.prop;
             val = getAtomProperty(atom, prop);
-            if (typeof scheme.map[val] !== "undefined") {
+            if (scheme.map[val] !== undefined) {
                 color = scheme.map[val];
             }
-        } else if (typeof style.colorscheme[atom.elem] !== "undefined") {
+        } else if (style.colorscheme[atom.elem] !== undefined) {
             //actual color scheme provided
             color = style.colorscheme[atom.elem];
         } else {
             console.log("Could not interpret colorscheme " + scheme);
         }
-    } else if (typeof style.colorfunc !== "undefined") {
+    } else if (style.colorfunc !== undefined) {
         //this is a user provided function for turning an atom into a color
         color = style.colorfunc(atom);
     }


### PR DESCRIPTION
# :dizzy: Changelog
:star: Updates TS files `src/*` to use strict equality operator.
:star: Only those conditions are updated where it is safe to update `==` to `===` and `!=` to `!==`. (E.g: statements where types of both the operands are known and same, operands that use `typeof` etc.)
:star: There still exist several statements where the operator is not updated as the logic might change (`==` returns true on comparing `null` and `undefined` whereas `===` returns false) or the types of operands are not known (`any`). Updating this requires manual efforts and it'll be easier once the type safety of the library has been improved. 
:star: The operators still need to be updated in these paths: `src/parsers`, `src/WebGL` which will be done on a separate PR (because it'll be difficult to self-review large file changes before submitting PR) 