### PR TITLE
Refactor remaining files in parser/utils

### DIFF
--- a/src/parsers/utils/assignBonds.ts
+++ b/src/parsers/utils/assignBonds.ts
@@ -21,7 +21,7 @@ const OFFSETS = [
 ];
 const MAX_BOND_LENGTH = 4.95; // (largest bond length, Cs) 2.25 * 2 * 1.1 (fudge factor)
 
-export function assignBonds(atoms: string | any[]) {
+export function assignBonds(atoms: AtomSpec[]) {
   // Assign bonds - yuck, can't count on connect records
 
   for (let i = 0, n = atoms.length; i < n; i++) {
@@ -29,7 +29,14 @@ export function assignBonds(atoms: string | any[]) {
     if (!atoms[i].index) atoms[i].index = i;
   }
 
-  const grid = {};
+  let grid: {
+    x: {
+      y: {
+        z: AtomSpec[];
+      };
+    };
+  };
+
   for (let index = 0; index < atoms.length; index++) {
     const atom = atoms[index];
     const x = Math.floor(atom.x / MAX_BOND_LENGTH);
@@ -76,7 +83,7 @@ export function assignBonds(atoms: string | any[]) {
         }
       }
     }
-  };
+  }
 
   for (let xg in grid) {
     const x = parseInt(xg);

--- a/src/parsers/utils/assignBonds.ts
+++ b/src/parsers/utils/assignBonds.ts
@@ -29,12 +29,18 @@ export function assignBonds(atoms: AtomSpec[]) {
     if (!atoms[i].index) atoms[i].index = i;
   }
 
-  let grid: {
+  const grid: {
     x: {
       y: {
         z: AtomSpec[];
       };
     };
+  } = {
+    x: {
+      y: {
+        z: [],
+      },
+    },
   };
 
   for (let index = 0; index < atoms.length; index++) {

--- a/src/parsers/utils/assignPDBBonds.ts
+++ b/src/parsers/utils/assignPDBBonds.ts
@@ -1,22 +1,21 @@
 // This is optimized for proteins where it is assumed connected atoms are on the same or next residue
 
+import { AtomSpec } from "specs";
 import { areConnected } from "./areConnected";
 import { assignBonds } from "./assignBonds";
 import { standardResidues } from "./standardResidues";
 
-
-/** 
+/**
  * @param {AtomSpec[]}
  *            atomsarray
-*/
+ */
 
-export function assignPDBBonds(atomsarray: string | any[]) {
+export function assignPDBBonds(atomsarray: AtomSpec[]) {
   // assign bonds - yuck, can't count on connect records
-  var protatoms: any[] = [];
-  var hetatoms: any[] = [];
-  var i: number, n: number;
-  for (i = 0, n = atomsarray.length; i < n; i++) {
-    var atom: any = atomsarray[i];
+  const protatoms: Array<AtomSpec> = [];
+  const hetatoms: Array<AtomSpec> = [];
+  for (let i = 0, n = atomsarray.length; i < n; i++) {
+    const atom = atomsarray[i];
     atom.index = i;
     if (atom.hetflag || !standardResidues.has(atom.resn)) hetatoms.push(atom);
     else protatoms.push(atom);
@@ -25,18 +24,18 @@ export function assignPDBBonds(atomsarray: string | any[]) {
   assignBonds(hetatoms);
 
   // sort by resid
-  protatoms.sort(function (a: any, b: any) {
-    if (a.chain != b.chain) return a.chain < b.chain ? -1 : 1;
+  protatoms.sort(function (a, b) {
+    if (a.chain !== b.chain) return a.chain < b.chain ? -1 : 1;
     return a.resi - b.resi;
   });
 
   // for identifying connected residues
-  var currentResi = -1;
-  var reschain = -1;
-  var lastResConnected: boolean;
+  let currentResi = -1;
+  let reschain = -1;
+  let lastResConnected: boolean;
 
-  for (i = 0, n = protatoms.length; i < n; i++) {
-    var ai = protatoms[i];
+  for (let i = 0, n = protatoms.length; i < n; i++) {
+    const ai = protatoms[i];
 
     if (ai.resi !== currentResi) {
       currentResi = ai.resi;
@@ -47,12 +46,10 @@ export function assignPDBBonds(atomsarray: string | any[]) {
 
     ai.reschain = reschain;
 
-    for (var j = i + 1; j < protatoms.length; j++) {
-      var aj = protatoms[j];
-      if (aj.chain != ai.chain) break;
-      if (aj.resi - ai.resi > 1)
-        // can't be connected
-        break;
+    for (let j = i + 1; j < protatoms.length; j++) {
+      const aj = protatoms[j];
+      if (aj.chain !== ai.chain || aj.resi - ai.resi > 1) break;
+
       if (areConnected(ai, aj)) {
         if (ai.bonds.indexOf(aj.index) === -1) {
           // only add if not already there

--- a/src/parsers/utils/getSinglePDB.ts
+++ b/src/parsers/utils/getSinglePDB.ts
@@ -22,7 +22,7 @@ export function getSinglePDB(
   const computeStruct = !options.noComputeSecondaryStructure;
   const noAssembly = !options.doAssembly; // don't assemble by default
   const selAltLoc = options.altLoc ? options.altLoc : "A"; //default alternate location to select if present
-  let modelData: { symmetries: Matrix4[]; cryst: Cryst };
+  const modelData: { symmetries: Matrix4[]; cryst: Cryst } = {symmetries:[], cryst: undefined};
   //atom name
   let atom: string;
   let remainingLines = [];

--- a/src/parsers/utils/isEmpty.ts
+++ b/src/parsers/utils/isEmpty.ts
@@ -1,6 +1,8 @@
-export function isEmpty(obj: { [x: string]: { [x: string]: any; }; hasOwnProperty?: any; }) {
-  var name: string;
-  for (name in obj) {
+export function isEmpty(obj: {
+  [x: string]: { [x: string]: unknown };
+  hasOwnProperty?: any;
+}) {
+  for (const _ in obj) {
     return false;
   }
   return true;

--- a/src/parsers/utils/validateBonds.ts
+++ b/src/parsers/utils/validateBonds.ts
@@ -1,18 +1,20 @@
+import { AtomSpec } from "specs";
+
 // Make sure bonds are actually two way
-export function validateBonds (atomsarray: string[] | any[], serialToIndex: number[]) {
+export function validateBonds(atomsarray: AtomSpec[], serialToIndex: number[]) {
   for (let i = 0, n = atomsarray.length; i < n; i++) {
-      const atom = atomsarray[i];
-      for(let b = 0; b < atom.bonds.length; b++) {
-          const a2i = atom.bonds[b];
-          const atom2 = atomsarray[a2i];
-          const atomi = serialToIndex[atom.serial];
-          if(atom2 && atomi) {
-              const a1i = atom2.bonds.indexOf(atomi);
-              if(a1i < 0) {
-                  atom2.bonds.push(atomi);
-                  atom2.bondOrder.push(atom.bondOrder[b]);
-              }
-          }
+    const atom = atomsarray[i];
+    for (let b = 0; b < atom.bonds.length; b++) {
+      const a2i = atom.bonds[b];
+      const atom2 = atomsarray[a2i];
+      const atomi = serialToIndex[atom.serial];
+      if (atom2 && atomi) {
+        const a1i = atom2.bonds.indexOf(atomi);
+        if (a1i < 0) {
+          atom2.bonds.push(atomi);
+          atom2.bondOrder.push(atom.bondOrder[b]);
+        }
       }
+    }
   }
-};
+}

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -1,16 +1,15 @@
 // Specifications for various object types used in 3Dmol.js
 // This is primarily for documentation
 
+import { Vector3 } from "WebGL";
 import { AtomStyleSpec, BondStyle, GLModel } from "./GLModel";
 import { GLViewer } from "./GLViewer";
 import { ColorSpec } from "./colors";
 
-
-
 /**
  * Atom representation. Depending on the input file format, not all fields may be defined.
  */
-export interface AtomSpec  {
+export interface AtomSpec {
   /** Parent residue name */
   resn?: string;
   /**  Atom's x coordinate  */
@@ -31,8 +30,8 @@ export interface AtomSpec  {
   chain?: string;
   /**  Residue number */
   resi?: number;
-  icode?: number;
-  rescode?: number;
+  icode?: string;
+  rescode?: string;
   /** Atom's serial id number */
   serial?: number;
   /** Index of atom in molecule */
@@ -78,7 +77,11 @@ export interface AtomSpec  {
   hbondDistanceSq?: number;
   hbondOther?: any;
   altLoc?: string;
-};
+  reschain?: number;
+  uMat?: Record<string, number>;
+  symmetries?: Vector3[];
+  sym?: any;
+}
 
 /**
  * Atom selection object. Used to specify what atoms should be selected.  Can include
@@ -96,9 +99,10 @@ export interface AtomSpec  {
  *  viewer.render();
  * });
  */
-export interface AtomSelectionSpec extends Omit<AtomSpec, "bonds"|"model"|"index"|"resi"> {
+export interface AtomSelectionSpec
+  extends Omit<AtomSpec, "bonds" | "model" | "index" | "resi"> {
   /** a single model or list of models from which atoms should be selected.  Can also specify by numerical creation order.  Reverse indexing is allowed (-1 specifies last added model). */
-  model?: GLModel | number |  GLModel[] | number[];
+  model?: GLModel | number | GLModel[] | number[];
   /** frame index of individual frame to style; will apply to all frames if not set */
   frame?: number;
   /** index of the atom or atoms to select */
@@ -114,19 +118,17 @@ export interface AtomSelectionSpec extends Omit<AtomSpec, "bonds"|"model"|"index
   /** if set, expands the selection to include all atoms of any residue that has any atom selected */
   byres?: boolean;
   /** expands the selection to include all atoms within a given distance from the selection */
-  expand?: number|string;
+  expand?: number | string;
   /** intersects the selection with the set of atoms within a given distance from another selection */
   within?: WithinSelectionSpec;
   /** take the intersection of the provided lists of {@link AtomSelectionSpec}s */
-  and?: AtomSelectionSpec[] & {__cached_results?: any};
+  and?: AtomSelectionSpec[] & { __cached_results?: any };
   /** take the union of the provided lists of {@link AtomSelectionSpec}s */
-  or?: AtomSelectionSpec[] & {__cached_results?: any};
+  or?: AtomSelectionSpec[] & { __cached_results?: any };
   /** take the inverse of the provided {@link AtomSelectionSpec} */
   not?: AtomSelectionSpec;
   contextMenuEnabled?: boolean;
-};
-
-
+}
 
 /**
  * Within selection object. Used to find the subset of an atom selection that is within
@@ -147,6 +149,14 @@ export interface WithinSelectionSpec {
   invert?: boolean;
   /** the selection of atoms against which to measure the distance from the parent atom selection */
   sel?: AtomSelectionSpec;
-};
+}
 
+export type Cryst = {
+  a: number;
+  b: number;
+  c: number;
+  alpha: number;
+  beta: number;
+  gamma: number;
+};
 export type SelectionRange = `${number}-${number}`;


### PR DESCRIPTION
# :dizzy: Changelog
:star: Improved typesafety in the remaining TS files located in `parser/utils`.
:star: Changed `var` to `let` and `const` as applicable.
:star: Added strict equality check
:star: If the name of identifiers of key and value are the same, do not pass the value identifier explicitly. E.g: Instead of using `atoms.push({x:x,y:y})` simply use `atoms.push({x,y})`
 