### PR TITLE
remove leftover debug code: console.log() calls

### DIFF
--- a/src/GLViewer.ts
+++ b/src/GLViewer.ts
@@ -664,7 +664,7 @@ export class GLViewer {
             this.intwatcher = new window.IntersectionObserver(intcallback);
             this.intwatcher.observe(this.container);
         }
-          
+
         try {
             if (typeof (this.callback) === "function")
                 this.callback(this);
@@ -1359,8 +1359,8 @@ export class GLViewer {
         this.WIDTH = this.getWidth();
         this.HEIGHT = this.getHeight();
         let regen = false;
-        console.log("resize "+this.container.id);
-        console.log("lost "+this.renderer.isLost() + " w"+this.WIDTH+ " h"+this.HEIGHT);
+        // console.log("resize "+this.container.id);
+        // console.log("lost "+this.renderer.isLost() + " w"+this.WIDTH+ " h"+this.HEIGHT);
         if (this.renderer.isLost() && this.WIDTH > 0 && this.HEIGHT > 0) {
             //create new context
             let resetcanvas = false;
@@ -1380,10 +1380,10 @@ export class GLViewer {
             this.renderer.setClearColorHex(this.bgColor, this.config.backgroundAlpha);
 
             regen = true;
-            if(resetcanvas) {
+            if (resetcanvas) {
                 this.config.canvas = this.renderer.getCanvas();
             }
-            console.log("regen "+regen+"  resetcanvas "+resetcanvas);
+            // console.log("regen "+regen+"  resetcanvas "+resetcanvas);
 
         }
         if (this.WIDTH == 0 || this.HEIGHT == 0) {
@@ -4452,7 +4452,7 @@ export class GLViewer {
 
                     var efunction = function (event) {
                         releaseMemory();
-                        console.log(event.message + " (" + event.filename + ":" + event.lineno + ")");
+                        // console.log(event.message + " (" + event.filename + ":" + event.lineno + ")");
                         reject(event);
                     };
 


### PR DESCRIPTION
Hello,

After upgrading to 2.2.1, I realized my console was polluted by what appears to be leftover debug code:

![2024-07-18-005125_1106x162_scrot](https://github.com/user-attachments/assets/76d89592-0c81-41a2-ac00-3e5dbff11a40)

I commented out the culprit lines. Also removed some whitespace and added a spacing after an if.

My recommendations:

- use `console.err()` or `console.warn()` when you wish to log an error or a warning
- actually, don't use directly `console` but have a generic function such as `log(level, msg)` where you provide a level (debug, notice, warn, err) and the wrapper will only emit a message in the console if the loglevel is below the message level. So in dev you'll have your loglevel to "show me everything", and in prod it will just show the warn and errors. This will allow you to leave the debug lines in your code instead of having to comment them out, which is prone to errors.
- use a linter that will warn you if `console.log()` calls are present (https://eslint.org/docs/latest/rules/no-console)
- same linter can also automatically fix trailing whitespaces, incorrect indent or incorrect spacing for expressions

Best,
~Nicolas
